### PR TITLE
🔀 :: [#350] 라디오 버튼 선택 범위 확장

### DIFF
--- a/App/Sources/DesignSystem/View/DetailView.swift
+++ b/App/Sources/DesignSystem/View/DetailView.swift
@@ -78,7 +78,8 @@ struct DetailView: View {
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(links, id: \.self) { link in
                     if let url = URL(string: link) {
-                        Link(destination: url,
+                        Link(
+                            destination: url,
                             label: {
                                 BitgouelText(
                                     text: "\(url)",

--- a/App/Sources/DesignSystem/View/DetailView.swift
+++ b/App/Sources/DesignSystem/View/DetailView.swift
@@ -67,13 +67,13 @@ struct DetailView: View {
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(links, id: \.self) { link in
                     if let url = URL(string: link) {
-                        Link(
-                            destination: url,
+                        Link(destination: url,
                             label: {
                                 BitgouelText(
                                     text: "\(url)",
                                     font: .caption
                                 )
+                                .multilineTextAlignment(.leading)
                             }
                         )
                     }

--- a/App/Sources/DesignSystem/View/DetailView.swift
+++ b/App/Sources/DesignSystem/View/DetailView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct DetailView: View {
     let title: String
     let content: String
+    let writer: String
+    let modifiedAt: String
     let links: [String]
     let writtenBy: Bool
     let deleteAction: () -> Void
@@ -11,12 +13,21 @@ struct DetailView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 4) {
                 BitgouelText(
                     text: title,
                     font: .text1
                 )
                 .padding(.top, 4)
+
+                HStack {
+                    Text("\(modifiedAt)에 게시")
+
+                    Spacer()
+
+                    Text(writer)
+                }
+                .bitgouelFont(.caption, color: .greyscale(.g7))
             }
 
             Divider()

--- a/App/Sources/DesignSystem/View/LinkDetailSettingView.swift
+++ b/App/Sources/DesignSystem/View/LinkDetailSettingView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct LinkDetailSettingView: View {
     @State var links: [String]
-    let link: String
+    @State var isErrorOccurred: Bool = false
     let dismiss: DismissAction
     var applyButtonTapAction: ([String]) -> Void
 
@@ -49,11 +49,19 @@ struct LinkDetailSettingView: View {
                 text: "적용하기",
                 style: .primary
             ) {
-                applyButtonTapAction(links)
-                dismiss()
+                if validateLinks() {
+                    applyButtonTapAction(links)
+                    dismiss()
+                } else {
+                    isErrorOccurred = true
+                }
             }
             .padding(.bottom, 12)
         }
+        .bitgouelToast(
+            text: "유효하지 않은 URL입니다.",
+            isShowing: $isErrorOccurred
+        )
     }
 
     @ViewBuilder
@@ -61,11 +69,18 @@ struct LinkDetailSettingView: View {
         ForEach(links.indices, id: \.self) { index in
             BitgouelTextField(
                 "링크 입력 (선택)",
-                text: Binding(
-                    get: { links[index] },
-                    set: { newvalue in links[index] = newvalue }
-                )
+                text: $links[index]
             )
         }
+    }
+
+    func validateLinks() -> Bool {
+        let isLinkErrorOccurred = links.map { !checkLink($0) }
+        return !isLinkErrorOccurred.contains(true)
+    }
+
+    func checkLink(_ link: String) -> Bool {
+        let linkRegex = "^https://[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(/[a-zA-Z0-9.-]*)?$"
+        return NSPredicate(format: "SELF MATCHES %@", linkRegex).evaluate(with: link)
     }
 }

--- a/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListViewModel.swift
+++ b/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListViewModel.swift
@@ -34,7 +34,7 @@ final class AdminUserListViewModel: BaseViewModel {
                     approveStatus: ""
                 )
             } catch {
-                print(error.localizedDescription)
+                print()
             }
         }
     }

--- a/App/Sources/Feature/AdminUserListFeature/Source/Component/UserTypeFilterPopup.swift
+++ b/App/Sources/Feature/AdminUserListFeature/Source/Component/UserTypeFilterPopup.swift
@@ -73,5 +73,8 @@ struct UserTypeFilterPopup: View {
 
             Spacer()
         }
+        .onTapGesture {
+            onAuthoritySelect(authority)
+        }
     }
 }

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/Component/UserCohortFilterPopup.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/Component/UserCohortFilterPopup.swift
@@ -75,5 +75,8 @@ struct UserCohortFilterPopup: View {
 
             Spacer()
         }
+        .onTapGesture {
+            onCohortSelect(cohort)
+        }
     }
 }

--- a/App/Sources/Feature/ClubListFeature/Source/ClubListView.swift
+++ b/App/Sources/Feature/ClubListFeature/Source/ClubListView.swift
@@ -3,9 +3,9 @@ import SwiftUI
 struct ClubListView: View {
     @StateObject var viewModel: ClubListViewModel
     @Binding var selection: TabFlow
-    
+
     private let clubDetailFactory: any ClubDetailFactory
-    
+
     init(
         viewModel: ClubListViewModel,
         clubDetailFactory: any ClubDetailFactory,
@@ -15,7 +15,7 @@ struct ClubListView: View {
         self.clubDetailFactory = clubDetailFactory
         _selection = selection
     }
-    
+
     var body: some View {
         NavigationView {
             ZStack {
@@ -24,10 +24,11 @@ struct ClubListView: View {
                         ForEach(viewModel.schoolClubList, id: \.id) { school in
                             SchoolListView(
                                 schoolName: school.schoolName,
-                                clubList: school.clubs) { clubID in
-                                    viewModel.updateClubID(clubID: clubID)
-                                    viewModel.updateIsPresentedClubDetailView(isPresented: true)
-                                }
+                                clubList: school.clubs
+                            ) { clubID in
+                                viewModel.updateClubID(clubID: clubID)
+                                viewModel.updateIsPresentedClubDetailView(isPresented: true)
+                            }
                         }
                     }
                     .padding(.horizontal, 28)
@@ -40,7 +41,7 @@ struct ClubListView: View {
                             .onTapGesture {
                                 viewModel.isPresentedSelectedSchoolPopup = false
                             }
-                        
+
                         SchoolListPopup(
                             schoolList: viewModel.schoolList,
                             selectedSchool: viewModel.selectedSchool

--- a/App/Sources/Feature/ClubListFeature/Source/Component/SchoolListView.swift
+++ b/App/Sources/Feature/ClubListFeature/Source/Component/SchoolListView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import Service
+import SwiftUI
 
 public struct SchoolListView: View {
     let schoolName: String
@@ -13,14 +13,14 @@ public struct SchoolListView: View {
                     text: schoolName,
                     font: .title3
                 )
-                
+
                 Spacer()
             }
             .padding(.top, 40)
-            
+
             Divider()
                 .padding(.top, 12)
-            
+
             LazyVStack(spacing: 0) {
                 ForEach(clubList, id: \.id) { club in
                     ClubListRow(clubName: club.name)
@@ -30,9 +30,8 @@ public struct SchoolListView: View {
                 }
             }
             .padding(.top, 8)
-            
+
             Spacer()
         }
-
     }
 }

--- a/App/Sources/Feature/InquiryListFeature/Source/Component/AnswerFilterPopup.swift
+++ b/App/Sources/Feature/InquiryListFeature/Source/Component/AnswerFilterPopup.swift
@@ -81,6 +81,9 @@ struct AnswerFilterPopup: View {
 
             Spacer()
         }
+        .onTapGesture {
+            onAnswerSelect(answer)
+        }
         .id(answer)
         .frame(height: 54)
     }

--- a/App/Sources/Feature/InquiryListFeature/Source/InquiryListView.swift
+++ b/App/Sources/Feature/InquiryListFeature/Source/InquiryListView.swift
@@ -19,44 +19,43 @@ struct InquiryListView: View {
 
     var body: some View {
         ZStack {
-            if viewModel.inquiryList.isEmpty {
-                NoInfoView(text: "문의사항이 없어요")
-            } else {
-                VStack(spacing: 4) {
-                    if viewModel.authority == .admin {
-                        KeywordSearchBar(
-                            text: Binding(
-                                get: { viewModel.keyword },
-                                set: { text in viewModel.updateKeyword(text: text) }
-                            ),
-                            prompt: "키워드로 검색..."
-                        ) {
-                            viewModel.updateIsPresentedFilter(isPresented: true)
-                        }
+            ScrollView(showsIndicators: true) {
+                if viewModel.authority == .admin {
+                    KeywordSearchBar(
+                        text: Binding(
+                            get: { viewModel.keyword },
+                            set: { text in viewModel.updateKeyword(text: text) }
+                        ),
+                        prompt: "키워드로 검색..."
+                    ) {
+                        viewModel.updateIsPresentedFilter(isPresented: true)
                     }
-                    
-                    ScrollView {
-                        VStack(spacing: 12) {
-                            ForEach(viewModel.inquiryList, id: \.inquiryID) { inquiry in
-                                InquiryListRow(
-                                    id: inquiry.inquiryID,
-                                    title: inquiry.question,
-                                    date: inquiry.createdAt,
-                                    userID: inquiry.userID,
-                                    name: inquiry.username,
-                                    state: inquiry.answerStatus,
-                                    authority: viewModel.authority
-                                )
-                                .onTapGesture {
-                                    viewModel.updateInquiryID(inquiryID: inquiry.inquiryID)
-                                    viewModel.updateIsPresentedInquiryDetailView(isPresented: true)
-                                }
+                }
+
+                if viewModel.inquiryList.isEmpty {
+                    NoInfoView(text: "문의사항이 없어요")
+                        .padding(.top, 100)
+                } else {
+                    LazyVStack(spacing: 12) {
+                        ForEach(viewModel.inquiryList, id: \.inquiryID) { inquiry in
+                            InquiryListRow(
+                                id: inquiry.inquiryID,
+                                title: inquiry.question,
+                                date: inquiry.createdAt,
+                                userID: inquiry.userID,
+                                name: inquiry.username,
+                                state: inquiry.answerStatus,
+                                authority: viewModel.authority
+                            )
+                            .onTapGesture {
+                                viewModel.updateInquiryID(inquiryID: inquiry.inquiryID)
+                                viewModel.updateIsPresentedInquiryDetailView(isPresented: true)
                             }
                         }
                     }
                 }
-                .padding(.horizontal, 28)
             }
+            .padding(.horizontal, 28)
 
             ZStack(alignment: .center) {
                 if viewModel.isPresentedFilter {

--- a/App/Sources/Feature/InquiryListFeature/Source/InquiryListView.swift
+++ b/App/Sources/Feature/InquiryListFeature/Source/InquiryListView.swift
@@ -19,9 +19,8 @@ struct InquiryListView: View {
 
     var body: some View {
         ZStack {
-            if viewModel.isLoading {
-                ProgressView()
-                    .progressViewStyle(.circular)
+            if viewModel.inquiryList.isEmpty {
+                NoInfoView(text: "문의사항이 없어요")
             } else {
                 VStack(spacing: 4) {
                     if viewModel.authority == .admin {
@@ -35,26 +34,22 @@ struct InquiryListView: View {
                             viewModel.updateIsPresentedFilter(isPresented: true)
                         }
                     }
-
+                    
                     ScrollView {
-                        if viewModel.inquiryList.isEmpty {
-                            NoInfoView(text: "문의사항이 없어요")
-                        } else {
-                            VStack(spacing: 12) {
-                                ForEach(viewModel.inquiryList, id: \.inquiryID) { inquiry in
-                                    InquiryListRow(
-                                        id: inquiry.inquiryID,
-                                        title: inquiry.question,
-                                        date: inquiry.createdAt,
-                                        userID: inquiry.userID,
-                                        name: inquiry.username,
-                                        state: inquiry.answerStatus,
-                                        authority: viewModel.authority
-                                    )
-                                    .onTapGesture {
-                                        viewModel.updateInquiryID(inquiryID: inquiry.inquiryID)
-                                        viewModel.updateIsPresentedInquiryDetailView(isPresented: true)
-                                    }
+                        VStack(spacing: 12) {
+                            ForEach(viewModel.inquiryList, id: \.inquiryID) { inquiry in
+                                InquiryListRow(
+                                    id: inquiry.inquiryID,
+                                    title: inquiry.question,
+                                    date: inquiry.createdAt,
+                                    userID: inquiry.userID,
+                                    name: inquiry.username,
+                                    state: inquiry.answerStatus,
+                                    authority: viewModel.authority
+                                )
+                                .onTapGesture {
+                                    viewModel.updateInquiryID(inquiryID: inquiry.inquiryID)
+                                    viewModel.updateIsPresentedInquiryDetailView(isPresented: true)
                                 }
                             }
                         }
@@ -128,9 +123,5 @@ struct InquiryListView: View {
         .onAppear {
             viewModel.onAppear()
         }
-        .bitgouelToast(
-            text: viewModel.errorMessage,
-            isShowing: $viewModel.isErrorOccurred
-        )
     }
 }

--- a/App/Sources/Feature/InquiryListFeature/Source/InquiryListViewModel.swift
+++ b/App/Sources/Feature/InquiryListFeature/Source/InquiryListViewModel.swift
@@ -76,8 +76,7 @@ final class InquiryListViewModel: BaseViewModel {
                 updateContent(entity: inquiryInfo)
                 isLoading = false
             } catch {
-                errorMessage = error.inquiryDomainErrorMessage()
-                isErrorOccurred = true
+                print(error.localizedDescription)
             }
         }
     }

--- a/App/Sources/Feature/NoticeDetailFeature/Source/NoticeDetailView.swift
+++ b/App/Sources/Feature/NoticeDetailFeature/Source/NoticeDetailView.swift
@@ -23,6 +23,8 @@ struct NoticeDetailView: View {
                 DetailView(
                     title: viewModel.noticeDetail?.title ?? "",
                     content: viewModel.noticeDetail?.content ?? "",
+                    writer: viewModel.noticeDetail?.writer ?? "",
+                    modifiedAt: viewModel.noticeDetail?.modifiedAt.toStringCustomFormat(format: "yyyy.MM.dd") ?? "",
                     links: viewModel.noticeDetail?.links ?? [""],
                     writtenBy: viewModel.noticeDetail?.writtenBy ?? false,
                     deleteAction: {

--- a/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingView.swift
+++ b/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingView.swift
@@ -13,10 +13,9 @@ struct NoticeDetailSettingView: View {
             VStack(spacing: 0) {
                 LinkDetailSettingView(
                     links: viewModel.noticeLinks,
-                    link: viewModel.link,
                     dismiss: dismiss
                 ) { links in
-                    viewModel.applyButtonDidTap(link: links)
+                    viewModel.applyButtonDidTap(links: links)
                 }
             }
             .padding(.horizontal, 28)

--- a/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingViewModel.swift
+++ b/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingViewModel.swift
@@ -15,8 +15,8 @@ final class NoticeDetailSettingViewModel: BaseViewModel {
         self.completion = completion
     }
 
-    func applyButtonDidTap(link: [String]) {
-        noticeLinks = link
+    func applyButtonDidTap(links: [String]) {
+        noticeLinks = links
         completion(noticeLinks)
     }
 }

--- a/App/Sources/Feature/NoticeListFeature/Source/NoticeListView.swift
+++ b/App/Sources/Feature/NoticeListFeature/Source/NoticeListView.swift
@@ -118,9 +118,5 @@ struct NoticeListView: View {
         .refreshable {
             viewModel.onAppear()
         }
-        .bitgouelToast(
-            text: viewModel.errorMessage,
-            isShowing: $viewModel.isErrorOccurred
-        )
     }
 }

--- a/App/Sources/Feature/NoticeListFeature/Source/NoticeListViewModel.swift
+++ b/App/Sources/Feature/NoticeListFeature/Source/NoticeListViewModel.swift
@@ -53,8 +53,7 @@ final class NoticeListViewModel: BaseViewModel {
 
                 isLoading = false
             } catch {
-                errorMessage = error.postDomainErrorMessage()
-                isErrorOccurred = true
+                print(error.localizedDescription)
             }
         }
     }

--- a/App/Sources/Feature/PostDetailFeature/Source/PostDetailView.swift
+++ b/App/Sources/Feature/PostDetailFeature/Source/PostDetailView.swift
@@ -23,6 +23,8 @@ struct PostDetailView: View {
                 DetailView(
                     title: viewModel.postDetail?.title ?? "",
                     content: viewModel.postDetail?.content ?? "",
+                    writer: viewModel.postDetail?.writer ?? "",
+                    modifiedAt: viewModel.postDetail?.modifiedAt.toStringCustomFormat(format: "yyyy.MM.dd") ?? "",
                     links: viewModel.postDetail?.links ?? [""],
                     writtenBy: viewModel.postDetail?.writtenBy ?? false,
                     deleteAction: {

--- a/App/Sources/Feature/PostDetailSettingFeature/Source/PostDetailSettingView.swift
+++ b/App/Sources/Feature/PostDetailSettingFeature/Source/PostDetailSettingView.swift
@@ -9,10 +9,9 @@ struct PostDetailSettingView: View {
             VStack(spacing: 0) {
                 LinkDetailSettingView(
                     links: viewModel.inputLinks,
-                    link: viewModel.link,
                     dismiss: dismiss
                 ) { links in
-                    viewModel.applyButtonDidTap(link: links)
+                    viewModel.applyButtonDidTap(links: links)
                 }
             }
             .padding(.horizontal, 28)

--- a/App/Sources/Feature/PostDetailSettingFeature/Source/PostDetailSettingViewModel.swift
+++ b/App/Sources/Feature/PostDetailSettingFeature/Source/PostDetailSettingViewModel.swift
@@ -2,7 +2,6 @@ import Foundation
 
 final class PostDetailSettingViewModel: BaseViewModel {
     @Published var inputLinks: [String] = [""]
-    @Published var link: String = ""
 
     private var completion: ([String]) -> Void
 
@@ -14,8 +13,8 @@ final class PostDetailSettingViewModel: BaseViewModel {
         self.completion = completion
     }
 
-    func applyButtonDidTap(link: [String]) {
-        inputLinks = link
+    func applyButtonDidTap(links: [String]) {
+        inputLinks = links
         completion(inputLinks)
     }
 }

--- a/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
+++ b/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
@@ -139,10 +139,6 @@ struct PostListView: View {
             ) {
                 $selection.wrappedValue = .home
             }
-            .bitgouelToast(
-                text: viewModel.errorMessage,
-                isShowing: $viewModel.isErrorOccurred
-            )
         }
     }
 }

--- a/App/Sources/Feature/PostListFeature/Sources/PostListViewModel.swift
+++ b/App/Sources/Feature/PostListFeature/Sources/PostListViewModel.swift
@@ -44,8 +44,7 @@ final class PostListViewModel: BaseViewModel {
                 do {
                     postContent = try await fetchPostListUseCase(postType: .employment)
                 } catch {
-                    errorMessage = error.postDomainErrorMessage()
-                    isErrorOccurred = true
+                    print(error.localizedDescription)
                 }
             }
         }

--- a/App/Sources/Feature/SignUpFeature/SignUpView.swift
+++ b/App/Sources/Feature/SignUpFeature/SignUpView.swift
@@ -136,7 +136,7 @@ struct SignUpView: View {
                 searchText: $viewModel.clubSearch,
                 searchedClubList: viewModel.searchedClubList,
                 selectedClub: viewModel.selectedClub ?? "동아리",
-                clubDidSelect: { selectedClub in
+                onClubSelect: { selectedClub in
                     viewModel.selectedClub = selectedClub
                     viewModel.isPresentedClubSheet = false
                 }
@@ -387,6 +387,10 @@ struct SignUpView: View {
                         )
                     )
                 }
+                .onTapGesture {
+                    viewModel.isPresentedUserRoleSheet = false
+                    viewModel.selectedUserRole = userRole
+                }
                 .padding(.horizontal, 28)
                 .padding(.vertical, 24)
             }
@@ -413,6 +417,10 @@ struct SignUpView: View {
                             }
                         )
                     )
+                }
+                .onTapGesture {
+                    viewModel.isPresentedAssociationSheet = false
+                    viewModel.selectedAssociation = association
                 }
                 .padding(.horizontal, 28)
                 .padding(.vertical, 24)

--- a/App/Sources/Feature/SignUpFeature/View/SchoolListRow.swift
+++ b/App/Sources/Feature/SignUpFeature/View/SchoolListRow.swift
@@ -23,6 +23,9 @@ struct SchoolListRow: View {
                 )
             )
         }
+        .onTapGesture {
+            onHighSchoolSelect(school)
+        }
         .id(String(school.rawValue))
         .frame(height: 73)
         .padding(.horizontal, 28)

--- a/App/Sources/Feature/SignUpFeature/View/SearchClubListBottomSheet.swift
+++ b/App/Sources/Feature/SignUpFeature/View/SearchClubListBottomSheet.swift
@@ -4,18 +4,18 @@ struct SearchClubListBottomSheet: View {
     @Binding var searchText: String
     let searchedClubList: [String]
     let selectedClub: String
-    let clubDidSelect: (String) -> Void
+    let onClubSelect: (String) -> Void
 
     init(
         searchText: Binding<String>,
         searchedClubList: [String],
         selectedClub: String,
-        clubDidSelect: @escaping (String) -> Void
+        onClubSelect: @escaping (String) -> Void
     ) {
         self._searchText = searchText
         self.searchedClubList = searchedClubList
         self.selectedClub = selectedClub
-        self.clubDidSelect = clubDidSelect
+        self.onClubSelect = onClubSelect
     }
 
     var body: some View {
@@ -31,10 +31,8 @@ struct SearchClubListBottomSheet: View {
                     ForEach(searchedClubList, id: \.self) { club in
                         SearchClubListRow(
                             club: club,
-                            isSelected: Binding(
-                                get: { club == selectedClub },
-                                set: { _ in clubDidSelect(club) }
-                            )
+                            selectedClub: selectedClub,
+                            onClubSelect: onClubSelect
                         )
                     }
                 }

--- a/App/Sources/Feature/SignUpFeature/View/SearchClubListRow.swift
+++ b/App/Sources/Feature/SignUpFeature/View/SearchClubListRow.swift
@@ -3,12 +3,8 @@ import SwiftUI
 
 struct SearchClubListRow: View {
     let club: String
-    @Binding var isSelected: Bool
-
-    init(club: String, isSelected: Binding<Bool>) {
-        self.club = club
-        self._isSelected = isSelected
-    }
+    let selectedClub: String?
+    let onClubSelect: (String) -> Void
 
     var body: some View {
         HStack {
@@ -16,7 +12,19 @@ struct SearchClubListRow: View {
 
             Spacer()
 
-            BitgouelRadioButton(isSelected: $isSelected)
+            BitgouelRadioButton(
+                isSelected: Binding(
+                    get: { selectedClub == club },
+                    set: { isSelected in
+                        if isSelected {
+                            onClubSelect(club)
+                        }
+                    }
+                )
+            )
+        }
+        .onTapGesture {
+            onClubSelect(club)
         }
         .id(String(club))
         .frame(height: 73)

--- a/App/Sources/Feature/StudentInfoFeature/Source/Component/CertificationListRow.swift
+++ b/App/Sources/Feature/StudentInfoFeature/Source/Component/CertificationListRow.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import Service
+import SwiftUI
 
 struct CertificationListRow: View {
     let id: String

--- a/App/Sources/Utils/Extensions/Array+safe.swift
+++ b/App/Sources/Utils/Extensions/Array+safe.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension Array {
+    subscript (safe index: Array.Index) -> Element? {
+        get {
+            return indices ~= index ? self[index] : nil
+        }
+        set {
+            guard let element = newValue else { return }
+            self[index] = element
+        }
+    }
+}

--- a/Service/Sources/Domain/ClubDomain/DTO/Response/ClubResponseDTO.swift
+++ b/Service/Sources/Domain/ClubDomain/DTO/Response/ClubResponseDTO.swift
@@ -5,8 +5,8 @@ public struct ClubResponseDTO: Decodable {
     public let name: String
 }
 
-extension ClubResponseDTO {
-    public func toDomain() -> ClubEntity {
+public extension ClubResponseDTO {
+    func toDomain() -> ClubEntity {
         ClubEntity(
             id: id,
             name: name

--- a/Service/Sources/Domain/PostDomain/DTO/Response/PostDetailResponseDTO.swift
+++ b/Service/Sources/Domain/PostDomain/DTO/Response/PostDetailResponseDTO.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct PostDetailResponseDTO: Decodable {
     public let title: String
     public let writtenBy: Bool
+    public let writer: String
     public let content: String
     public let feedType: FeedType
     public let modifiedAt: String
@@ -11,6 +12,7 @@ public struct PostDetailResponseDTO: Decodable {
     public init(
         title: String,
         writtenBy: Bool,
+        writer: String,
         content: String,
         feedType: FeedType,
         modifiedAt: String,
@@ -18,6 +20,7 @@ public struct PostDetailResponseDTO: Decodable {
     ) {
         self.title = title
         self.writtenBy = writtenBy
+        self.writer = writer
         self.content = content
         self.feedType = feedType
         self.modifiedAt = modifiedAt
@@ -30,9 +33,10 @@ extension PostDetailResponseDTO {
         PostDetailEntity(
             title: title,
             writtenBy: writtenBy,
+            writer: writer,
             content: content,
             feedType: feedType,
-            modifiedAt: modifiedAt,
+            modifiedAt: modifiedAt.toDateCustomFormat(format: "yyyy-MM-dd'T'HH:mm:ss.SSS"),
             links: links
         )
     }

--- a/Service/Sources/Domain/PostDomain/Entity/PostDetailEntity.swift
+++ b/Service/Sources/Domain/PostDomain/Entity/PostDetailEntity.swift
@@ -3,21 +3,24 @@ import Foundation
 public struct PostDetailEntity: Equatable {
     public let title: String
     public let writtenBy: Bool
+    public let writer: String
     public let content: String
     public let feedType: FeedType
-    public let modifiedAt: String
+    public let modifiedAt: Date
     public let links: [String]
 
     public init(
         title: String,
         writtenBy: Bool,
+        writer: String,
         content: String,
         feedType: FeedType,
-        modifiedAt: String,
+        modifiedAt: Date,
         links: [String]
     ) {
         self.title = title
         self.writtenBy = writtenBy
+        self.writer = writer
         self.content = content
         self.feedType = feedType
         self.modifiedAt = modifiedAt

--- a/Service/Sources/Domain/SchoolDoamin/API/SchoolAPI.swift
+++ b/Service/Sources/Domain/SchoolDoamin/API/SchoolAPI.swift
@@ -1,5 +1,5 @@
-import Moya
 import Foundation
+import Moya
 
 public enum SchoolAPI {
     case fetchSchoolList


### PR DESCRIPTION
## 💡 배경 및 개요
기존의 라디오 버튼으로 선택할 때 범위가 좁아 버튼을 선택하는 데 불편함을 겪었어요.

Resolves: #350 

## 📃 작업내용
라디오 버튼이 사용되는 부분들에 onTapGesture를 한 번 더 감싸 더 넒은 범위에서 선택해도 선택되도록 수정했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?