### PR TITLE
🔀 :: [#386] 대학 목록 페이지 퍼블리싱

### DIFF
--- a/App/Sources/Feature/AdminBaseFeature/Source/Component/View/CountHeader.swift
+++ b/App/Sources/Feature/AdminBaseFeature/Source/Component/View/CountHeader.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public struct CountHeader: View {
+    let count: Int
+    let epic: String
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("총 \(count)개 \(epic)")
+                .bitgouelFont(.caption, color: .greyscale(.g4))
+                .padding(.top, 24)
+
+            Divider()
+        }
+    }
+}

--- a/App/Sources/Feature/OrganizationListFeature/Source/OrganizationListView.swift
+++ b/App/Sources/Feature/OrganizationListFeature/Source/OrganizationListView.swift
@@ -16,11 +16,7 @@ struct OrganizationListView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("총 \(viewModel.organizationList.count)개 \(viewModel.organization.display())")
-                .bitgouelFont(.caption, color: .greyscale(.g4))
-                .padding(.top, 24)
-
-            Divider()
+            CountHeader(count: viewModel.organizationList.count, epic: viewModel.organization.display())
 
             ScrollView(showsIndicators: false) {
                 LazyVStack(alignment: .leading, spacing: 12) {

--- a/App/Sources/Feature/SchoolListFeature/Source/SchoolListView.swift
+++ b/App/Sources/Feature/SchoolListFeature/Source/SchoolListView.swift
@@ -10,11 +10,7 @@ struct SchoolListView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("총 \(viewModel.schoolList.count)개 학교")
-                .bitgouelFont(.caption, color: .greyscale(.g4))
-                .padding(.top, 24)
-
-            Divider()
+            CountHeader(count: viewModel.schoolList.count, epic: "학교")
 
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 12) {

--- a/App/Sources/Feature/UniversityListFeature/Source/Component/UniversityDetailBottomSheet.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/Component/UniversityDetailBottomSheet.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct UniversityDetailInfoBottomSheet: View {
+    let universityName: String
+    let departmentList: [String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                BitgouelText(
+                    text: "대학 상세",
+                    font: .title3
+                )
+
+                Spacer()
+
+                Button {
+                    
+                } label: {
+                    
+                }
+            }
+        }
+    }
+}

--- a/App/Sources/Feature/UniversityListFeature/Source/Component/UniversityDetailBottomSheet.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/Component/UniversityDetailBottomSheet.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
-struct UniversityDetailInfoBottomSheet: View {
+struct UniversityDetailBottomSheet: View {
     let universityName: String
     let departmentList: [String]
+    let cancel: (Bool) -> Void
+    let editAction: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 32) {
             HStack {
                 BitgouelText(
                     text: "대학 상세",
@@ -15,11 +17,42 @@ struct UniversityDetailInfoBottomSheet: View {
                 Spacer()
 
                 Button {
-                    
+                    cancel(false)
                 } label: {
-                    
+                    BitgouelAsset.Icons.cancel.swiftUIImage
+                }
+            }
+
+            BitgouelText(
+                text: universityName,
+                font: .text1
+            )
+
+            VStack(alignment: .leading, spacing: 16) {
+                BitgouelText(
+                    text: "학과 목록",
+                    font: .text1
+                )
+
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        ForEach(departmentList, id: \.self) { department in
+                            Text(department)
+                                .bitgouelFont(.text3, color: .greyscale(.g4))
+                        }
+                    }
                 }
             }
         }
+        .overlay(alignment: .bottom) {
+            ActivateButton(
+                text: "정보 수정",
+                buttonType: .pen
+            ) {
+                editAction()
+            }
+        }
+        .padding(.horizontal, 28)
+        .frame(height: 500)
     }
 }

--- a/App/Sources/Feature/UniversityListFeature/Source/UniversityListView.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/UniversityListView.swift
@@ -9,9 +9,40 @@ struct UniversityListView: View {
     }
 
     var body: some View {
-        VStack {
-            Text("UniversityListView")
+        VStack(alignment: .leading, spacing: 12) {
+            CountHeader(count: viewModel.universityList.count, epic: "대학")
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach(viewModel.universityList, id: \.universityID) { university in
+                        AdminListPageRow(
+                            name: university.universityName,
+                            detailInfo: "\(university.departments.count)개 학과"
+                        )
+                        .onTapGesture {
+                            viewModel.updateSelectedUniversityInfo(
+                                name: university.universityName,
+                                departments: university.departments
+                            )
+
+                            viewModel.updateIsShowingUniversityDetailBottomSheet(isShowing: true)
+                        }
+
+                        Divider()
+                    }
+                }
+            }
         }
+        .overlay(alignment: .bottom) {
+            ActivateButton(
+                text: "새로운 대학 등록",
+                buttonType: .add
+            ) {
+                viewModel.updateIsPresentedInputUniversityPage(isPresented: true)
+            }
+        }
+        .padding(.horizontal, 28)
+        .navigationTitle("대학 목록")
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 Button {
@@ -32,6 +63,16 @@ struct UniversityListView: View {
                 adminPageState.adminPageFlow = page
             } cancel: { cancel in
                 viewModel.updateIsShowingAdminPageBottomSheet(isShowing: cancel)
+            }
+        }
+        .bitgouelBottomSheet(isShowing: $viewModel.isShowingUniversityDetailBottomSheet) {
+            UniversityDetailBottomSheet(
+                universityName: viewModel.selectedUniversityName,
+                departmentList: viewModel.selectedDepartmentList
+            ) { cancel in
+                viewModel.updateIsShowingUniversityDetailBottomSheet(isShowing: cancel)
+            } editAction: {
+                viewModel.updateIsPresentedInputUniversityPage(isPresented: true)
             }
         }
     }

--- a/App/Sources/Feature/UniversityListFeature/Source/UniversityListViewModel.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/UniversityListViewModel.swift
@@ -1,15 +1,34 @@
 import Foundation
+import Service
 
 final class UniversityListViewModel: BaseViewModel {
     @Published var isShowingAdminPageBottomSheet: Bool = false
+    @Published var isShowingUniversityDetailBottomSheet: Bool = false
+    @Published var isPresentedInputUniversityPage: Bool = false
     @Published var selectedPage: AdminPageFlow = .company
+    var universityList: [UniversityInfoEntity] = []
+    var selectedUniversityName: String = ""
+    var selectedDepartmentList: [String] = []
 
     func updateIsShowingAdminPageBottomSheet(isShowing: Bool) {
         isShowingAdminPageBottomSheet = isShowing
     }
 
+    func updateIsShowingUniversityDetailBottomSheet(isShowing: Bool) {
+        isShowingUniversityDetailBottomSheet = isShowing
+    }
+
+    func updateIsPresentedInputUniversityPage(isPresented: Bool) {
+        isPresentedInputUniversityPage = isPresented
+    }
+
     func updateSelectedPage(page: AdminPageFlow) {
         guard selectedPage != page else { return }
         selectedPage = page
+    }
+
+    func updateSelectedUniversityInfo(name: String, departments: [String]) {
+        selectedUniversityName = name
+        selectedDepartmentList = departments
     }
 }

--- a/Service/Sources/Domain/UniversityDomain/DTO/Response/UniversityListResponseDTO.swift
+++ b/Service/Sources/Domain/UniversityDomain/DTO/Response/UniversityListResponseDTO.swift
@@ -5,7 +5,7 @@ public struct UniversityListResponseDTO: Decodable {
 }
 
 public struct UniversityInfoResponseDTO: Decodable {
-    public let universityID: String
+    public let universityID: Int
     public let universityName: String
     public let departments: [String]
 

--- a/Service/Sources/Domain/UniversityDomain/Entity/UniversityInfoEntity.swift
+++ b/Service/Sources/Domain/UniversityDomain/Entity/UniversityInfoEntity.swift
@@ -1,7 +1,17 @@
 import Foundation
 
 public struct UniversityInfoEntity: Equatable {
-    public let universityID: String
+    public let universityID: Int
     public let universityName: String
     public let departments: [String]
+
+    public init(
+        universityID: Int,
+        universityName: String,
+        departments: [String]
+    ) {
+        self.universityID = universityID
+        self.universityName = universityName
+        self.departments = departments
+    }
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/1fe04056-de1d-4ee7-9838-b25a2d8fa17b


Resolves: #386 

## 📃 작업내용
- 대학 목록 페이지를 퍼블리싱 했어요.
- 총 N개의 대학... 기업 등 각 페이지의 목록마다 기업이 몇개가 있는지 알려주는 부분의 코드가 계속 반복되어서 CountHeader로 Component화 했어요.
- universityID의 Type을 String에서 Int로 변경했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?