### PR TITLE
🔀 :: [#386] 대학 입력 페이지 퍼블리싱

### DIFF
--- a/App/Sources/Application/DI/AppComponent.swift
+++ b/App/Sources/Application/DI/AppComponent.swift
@@ -190,4 +190,8 @@ public extension AppComponent {
     var inputOrganizationFactory: any InputOrganizationFactory {
         InputOrganizationComponent(parent: self)
     }
+
+    var inputUniversityFactory: any InputUniversityFactory {
+        InputUniversityComponent(parent: self)
+    }
 }

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -624,6 +624,9 @@ private class UniversityListDependency114351175c975dac12b7Provider: UniversityLi
     var fetchUniversityListUseCase: any FetchUniversityListUseCase {
         return appComponent.fetchUniversityListUseCase
     }
+    var inputUniversityFactory: any InputUniversityFactory {
+        return appComponent.inputUniversityFactory
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -797,6 +800,17 @@ private class LoginDependencyf4e78d0ad57be469bfd9Provider: LoginDependency {
 /// ^->AppComponent->LoginComponent
 private func factoryd6018e98563de75a2ba4f47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
     return LoginDependencyf4e78d0ad57be469bfd9Provider(appComponent: parent1(component) as! AppComponent)
+}
+private class InputUniversityDependencyd59283d5aa3af708a885Provider: InputUniversityDependency {
+
+
+    init() {
+
+    }
+}
+/// ^->AppComponent->InputUniversityComponent
+private func factoryb6aa118932d97d72500ae3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return InputUniversityDependencyd59283d5aa3af708a885Provider()
 }
 private class LectureListDependencyf05b805b4d41a7643bcdProvider: LectureListDependency {
     var lectureListDetailFactory: any LectureListDetailFactory {
@@ -1155,6 +1169,7 @@ extension StudentInfoComponent: Registration {
 extension UniversityListComponent: Registration {
     public func registerItems() {
         keyPathToName[\UniversityListDependency.fetchUniversityListUseCase] = "fetchUniversityListUseCase-any FetchUniversityListUseCase"
+        keyPathToName[\UniversityListDependency.inputUniversityFactory] = "inputUniversityFactory-any InputUniversityFactory"
     }
 }
 extension WriteInquiryAnswerComponent: Registration {
@@ -1216,6 +1231,11 @@ extension LoginComponent: Registration {
         keyPathToName[\LoginDependency.signupFactory] = "signupFactory-any SignUpFactory"
         keyPathToName[\LoginDependency.saveUserAuthorityUseCase] = "saveUserAuthorityUseCase-any SaveUserAuthorityUseCase"
         keyPathToName[\LoginDependency.findPasswordFactory] = "findPasswordFactory-any FindPasswordFactory"
+    }
+}
+extension InputUniversityComponent: Registration {
+    public func registerItems() {
+
     }
 }
 extension LectureListComponent: Registration {
@@ -1405,6 +1425,7 @@ extension AppComponent: Registration {
         localTable["organizationListFactory-any OrganizationListFactory"] = { [unowned self] in self.organizationListFactory as Any }
         localTable["universityListFactory-any UniversityListFactory"] = { [unowned self] in self.universityListFactory as Any }
         localTable["inputOrganizationFactory-any InputOrganizationFactory"] = { [unowned self] in self.inputOrganizationFactory as Any }
+        localTable["inputUniversityFactory-any InputUniversityFactory"] = { [unowned self] in self.inputUniversityFactory as Any }
         localTable["remoteWithdrawDataSource-any RemoteWithdrawDataSource"] = { [unowned self] in self.remoteWithdrawDataSource as Any }
         localTable["withdrawRepository-any WithdrawRepository"] = { [unowned self] in self.withdrawRepository as Any }
         localTable["fetchWithdrawUserListUseCase-any FetchWithdrawUserListUseCase"] = { [unowned self] in self.fetchWithdrawUserListUseCase as Any }
@@ -1485,6 +1506,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->ActivityListComponent", factory7177e6769ee69064a61bf47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->InputLectureComponent", factory622e14688d9803ec3c64f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->LoginComponent", factoryd6018e98563de75a2ba4f47b58f8f304c97af4d5)
+    registerProviderFactory("^->AppComponent->InputUniversityComponent", factoryb6aa118932d97d72500ae3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->LectureListComponent", factorya2eac906a839dcacda45f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->PostDetailSettingComponent", factoryaacb19523586bb790cade3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->ActivityDetailComponent", factory7c395808ac9dfb8fb229f47b58f8f304c97af4d5)

--- a/App/Sources/Feature/InputUniversityFeature/Interface/InputUniversityFactory.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Interface/InputUniversityFactory.swift
@@ -1,0 +1,6 @@
+import SwiftUI
+
+public protocol InputUniversityFactory {
+    associatedtype SomeView: View
+    func makeView(state: String) -> SomeView
+}

--- a/App/Sources/Feature/InputUniversityFeature/Interface/InputUniversityFactory.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Interface/InputUniversityFactory.swift
@@ -2,5 +2,10 @@ import SwiftUI
 
 public protocol InputUniversityFactory {
     associatedtype SomeView: View
-    func makeView(state: String) -> SomeView
+    func makeView(
+        state: String,
+        universityName: String,
+        departmentList: [String],
+        universityID: Int
+    ) -> SomeView
 }

--- a/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityComponent.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityComponent.swift
@@ -4,7 +4,19 @@ import SwiftUI
 public protocol InputUniversityDependency: Dependency {}
 
 public final class InputUniversityComponent: Component<InputUniversityDependency>, InputUniversityFactory {
-    public func makeView(state: String) -> some View {
-        InputUniversityView()
+    public func makeView(
+        state: String,
+        universityName: String,
+        departmentList: [String],
+        universityID: Int
+    ) -> some View {
+        InputUniversityView(
+            viewModel: .init(
+                state: state,
+                universityName: universityName,
+                departmentList: departmentList,
+                universityID: universityID
+            )
+        )
     }
 }

--- a/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityComponent.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityComponent.swift
@@ -1,0 +1,10 @@
+import NeedleFoundation
+import SwiftUI
+
+public protocol InputUniversityDependency: Dependency {}
+
+public final class InputUniversityComponent: Component<InputUniversityDependency>, InputUniversityFactory {
+    public func makeView(state: String) -> some View {
+        InputUniversityView()
+    }
+}

--- a/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityView.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityView.swift
@@ -1,7 +1,143 @@
 import SwiftUI
 
 struct InputUniversityView: View {
+    @StateObject var viewModel: InputUniversityViewModel
+
+    init(viewModel: InputUniversityViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
     var body: some View {
-        Text("InputUniversityView")
+        VStack(alignment: .leading, spacing: 20) {
+            BitgouelTextField(
+                "대학 이름 입력",
+                text: $viewModel.universityName
+            )
+            .padding(.top, 36)
+
+            Spacer()
+
+            if viewModel.state == "수정" {
+                departmentFormView()
+            }
+        }
+        .overlay(alignment: .bottom) {
+            renderFormButtons()
+        }
+        .padding(.horizontal, 28)
+        .navigationTitle("대학 \(viewModel.state)")
+        .bitgouelAlert(
+            title: "대학을 삭제하시겠습니까?",
+            description: "",
+            isShowing: $viewModel.isShowingDeleteAlert,
+            alertActions: [
+                .init(
+                    text: "취소",
+                    style: .cancel,
+                    action: {
+                        viewModel.updateIsShowingDeleteAlert(isShowing: false)
+                    }
+                ),
+                .init(
+                    text: "삭제",
+                    style: .error,
+                    action: {
+                        viewModel.deleteUniversity()
+                    }
+                )
+            ]
+        )
+    }
+
+    @ViewBuilder
+    func departmentFormView() -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            BitgouelText(text: "학과 목록", font: .title3)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    ForEach(viewModel.departmentList.indices, id: \.self) { index in
+                        let department = viewModel.departmentList[safe: index]
+
+                        HStack {
+                            HStack {
+                                BitgouelText(
+                                    text: department ?? "",
+                                    font: .text3
+                                )
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 16)
+
+                                Spacer()
+                            }
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.bitgouel(.greyscale(.g7)))
+                            }
+
+                            Spacer()
+
+                            Button {
+                                viewModel.deleteDepartment(department: department ?? "")
+                            } label: {
+                                BitgouelAsset.Icons.minusFill.swiftUIImage
+                                    .resizable()
+                                    .renderingMode(.template)
+                                    .foregroundColor(Color.bitgouel(.error(.e5)))
+                                    .frame(width: 24, height: 24)
+                            }
+                        }
+                    }
+
+                    Button {
+                        viewModel.updateIsPresentedInputDepartment(isPresented: true)
+                    } label: {
+                        HStack {
+                            Text("학과 추가")
+
+                            Spacer()
+
+                            BitgouelAsset.Icons.add.swiftUIImage
+                                .renderingMode(.template)
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 16)
+                        .foregroundColor(.bitgouel(.greyscale(.g10)))
+                        .background(Color.bitgouel(.primary(.p5)))
+                        .cornerRadius(8, corners: .allCorners)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    func renderFormButtons() -> some View {
+        if viewModel.state == "수정" {
+            HStack {
+                DeactivateButton(
+                    text: "대학 삭제",
+                    buttonType: .minus
+                ) {
+                    viewModel.updateIsShowingDeleteAlert(isShowing: true)
+                }
+
+                Spacer()
+
+                ActivateButton(
+                    text: "수정 완료",
+                    buttonType: .check
+                ) {
+                    viewModel.editUniversity()
+                }
+            }
+        } else {
+            ActivateButton(
+                text: "대학 등록",
+                buttonType: .add
+            ) {
+                viewModel.createdUniversity()
+            }
+        }
     }
 }

--- a/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityView.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct InputUniversityView: View {
+    var body: some View {
+        Text("InputUniversityView")
+    }
+}

--- a/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityViewModel.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+final class InputUniversityViewModel: BaseViewModel {
+    
+}

--- a/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityViewModel.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityViewModel.swift
@@ -1,5 +1,47 @@
 import Foundation
 
 final class InputUniversityViewModel: BaseViewModel {
-    
+    @Published var universityName: String
+    @Published var departmentList: [String]
+    @Published var isShowingDeleteAlert: Bool = false
+    @Published var isPresentedInputDepartment: Bool = false
+    let state: String
+    let universityID: Int
+
+    init(
+        state: String,
+        universityName: String,
+        departmentList: [String],
+        universityID: Int
+    ) {
+        self.state = state
+        self.universityName = universityName
+        self.departmentList = departmentList
+        self.universityID = universityID
+    }
+
+    func updateIsShowingDeleteAlert(isShowing: Bool) {
+        isShowingDeleteAlert = isShowing
+    }
+
+    func updateIsPresentedInputDepartment(isPresented: Bool) {
+        isPresentedInputDepartment = isPresented
+    }
+
+    func editUniversity() {
+        #warning("대학 수정 기능 추가")
+    }
+
+    func createdUniversity() {
+        #warning("대학 등록 기능 추가")
+    }
+
+    func deleteUniversity() {
+        #warning("대학 삭제 기능 추가")
+    }
+
+    func deleteDepartment(department: String) {
+        guard department == "" else { return }
+        #warning("학과 삭제 기능 추가")
+    }
 }

--- a/App/Sources/Feature/OrganizationListFeature/Source/OrganizationListView.swift
+++ b/App/Sources/Feature/OrganizationListFeature/Source/OrganizationListView.swift
@@ -82,12 +82,34 @@ struct OrganizationListView: View {
             ) { cancel in
                 viewModel.updateIsShowingOrganizationDetailBottomSheet(isShowing: cancel)
             } deleteAction: {
-                viewModel.deleteOrganization {
-                    viewModel.updateIsShowingOrganizationDetailBottomSheet(isShowing: false)
-                    viewModel.onAppear()
-                }
+                viewModel.updateIsShowingDeleteAlert(isShowing: true)
             }
         }
+        .bitgouelAlert(
+            title: "\(viewModel.organization.rawValue)을 삭제하시겠습니까?",
+            description: "",
+            isShowing: $viewModel.isShowingDeleteAlert,
+            alertActions: [
+                .init(
+                    text: "취소",
+                    style: .cancel,
+                    action: {
+                        viewModel.updateIsShowingDeleteAlert(isShowing: false)
+                    }
+                ),
+                .init(
+                    text: "삭제",
+                    style: .error,
+                    action: {
+                        viewModel.deleteOrganization {
+                            viewModel.updateIsShowingDeleteAlert(isShowing: false)
+                            viewModel.updateIsShowingOrganizationDetailBottomSheet(isShowing: false)
+                            viewModel.onAppear()
+                        }
+                    }
+                )
+            ]
+        )
         .bitgouelToast(
             text: viewModel.errorMessage,
             isShowing: $viewModel.isErrorOccurred

--- a/App/Sources/Feature/OrganizationListFeature/Source/OrganizationListViewModel.swift
+++ b/App/Sources/Feature/OrganizationListFeature/Source/OrganizationListViewModel.swift
@@ -5,6 +5,7 @@ final class OrganizationListViewModel: BaseViewModel {
     @Published var isShowingAdminPageBottomSheet: Bool = false
     @Published var isShowingOrganizationDetailBottomSheet: Bool = false
     @Published var isPresentedInputOrganizationPage: Bool = false
+    @Published var isShowingDeleteAlert: Bool = false
     @Published var selectedPage: AdminPageFlow
     @Published var organizationList: [OrganizationListModel] = []
     @Published var selectedOrganizationName: String = ""
@@ -43,6 +44,10 @@ final class OrganizationListViewModel: BaseViewModel {
 
     func updateIsPresentedInputOrganizationPage(isPresented: Bool) {
         isPresentedInputOrganizationPage = isPresented
+    }
+
+    func updateIsShowingDeleteAlert(isShowing: Bool) {
+        isShowingDeleteAlert = isShowing
     }
 
     func updateSelectedPage(page: AdminPageFlow) {

--- a/App/Sources/Feature/UniversityListFeature/Source/UniversityListComponent.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/UniversityListComponent.swift
@@ -4,6 +4,7 @@ import Service
 
 public protocol UniversityListDependency: Dependency {
     var fetchUniversityListUseCase: any FetchUniversityListUseCase { get }
+    var inputUniversityFactory: any InputUniversityFactory { get }
 }
 
 public final class UniversityListComponent: Component<UniversityListDependency>, UniversityListFactory {
@@ -11,7 +12,8 @@ public final class UniversityListComponent: Component<UniversityListDependency>,
         UniversityListView(
             viewModel: .init(
                 fetchUniversityListUseCase: dependency.fetchUniversityListUseCase
-            )
+            ),
+            inputUniversityFactory: dependency.inputUniversityFactory
         )
     }
 }

--- a/App/Sources/Feature/UniversityListFeature/Source/UniversityListView.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/UniversityListView.swift
@@ -4,8 +4,14 @@ struct UniversityListView: View {
     @EnvironmentObject var adminPageState: AdminPageState
     @StateObject var viewModel: UniversityListViewModel
 
-    init(viewModel: UniversityListViewModel) {
+    private let inputUniversityFactory: any InputUniversityFactory
+
+    init(
+        viewModel: UniversityListViewModel,
+        inputUniversityFactory: any InputUniversityFactory
+    ) {
         _viewModel = StateObject(wrappedValue: viewModel)
+        self.inputUniversityFactory = inputUniversityFactory
     }
 
     var body: some View {
@@ -40,6 +46,7 @@ struct UniversityListView: View {
                 text: "새로운 대학 등록",
                 buttonType: .add
             ) {
+                viewModel.updateState(state: "등록")
                 viewModel.updateIsPresentedInputUniversityPage(isPresented: true)
             }
         }
@@ -74,8 +81,18 @@ struct UniversityListView: View {
             ) { cancel in
                 viewModel.updateIsShowingUniversityDetailBottomSheet(isShowing: cancel)
             } editAction: {
+                viewModel.updateState(state: "수정")
                 viewModel.updateIsPresentedInputUniversityPage(isPresented: true)
             }
         }
+        .navigate(
+            to: inputUniversityFactory.makeView(state: viewModel.state).eraseToAnyView(),
+            when: Binding(
+                get: { viewModel.isPresentedInputUniversityPage },
+                set: { isPresented in
+                    viewModel.updateIsPresentedInputUniversityPage(isPresented: isPresented)
+                }
+            )
+        )
     }
 }

--- a/App/Sources/Feature/UniversityListFeature/Source/UniversityListView.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/UniversityListView.swift
@@ -27,6 +27,7 @@ struct UniversityListView: View {
                         )
                         .onTapGesture {
                             viewModel.updateSelectedUniversityInfo(
+                                id: university.universityID, 
                                 name: university.universityName,
                                 departments: university.departments
                             )
@@ -86,7 +87,12 @@ struct UniversityListView: View {
             }
         }
         .navigate(
-            to: inputUniversityFactory.makeView(state: viewModel.state).eraseToAnyView(),
+            to: inputUniversityFactory.makeView(
+                state: viewModel.state,
+                universityName: viewModel.selectedUniversityName,
+                departmentList: viewModel.selectedDepartmentList,
+                universityID: viewModel.selectedUniversityID
+            ).eraseToAnyView(),
             when: Binding(
                 get: { viewModel.isPresentedInputUniversityPage },
                 set: { isPresented in

--- a/App/Sources/Feature/UniversityListFeature/Source/UniversityListViewModel.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/UniversityListViewModel.swift
@@ -7,6 +7,7 @@ final class UniversityListViewModel: BaseViewModel {
     @Published var isPresentedInputUniversityPage: Bool = false
     @Published var selectedPage: AdminPageFlow = .company
     @Published var universityList: [UniversityInfoEntity] = []
+    var state: String = ""
     var selectedUniversityName: String = ""
     var selectedDepartmentList: [String] = []
 
@@ -36,6 +37,10 @@ final class UniversityListViewModel: BaseViewModel {
     func updateSelectedUniversityInfo(name: String, departments: [String]) {
         selectedUniversityName = name
         selectedDepartmentList = departments
+    }
+
+    func updateState(state: String) {
+        self.state = state
     }
 
     @MainActor

--- a/App/Sources/Feature/UniversityListFeature/Source/UniversityListViewModel.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/UniversityListViewModel.swift
@@ -7,6 +7,7 @@ final class UniversityListViewModel: BaseViewModel {
     @Published var isPresentedInputUniversityPage: Bool = false
     @Published var selectedPage: AdminPageFlow = .company
     @Published var universityList: [UniversityInfoEntity] = []
+    var selectedUniversityID: Int = 0
     var state: String = ""
     var selectedUniversityName: String = ""
     var selectedDepartmentList: [String] = []
@@ -34,7 +35,8 @@ final class UniversityListViewModel: BaseViewModel {
         selectedPage = page
     }
 
-    func updateSelectedUniversityInfo(name: String, departments: [String]) {
+    func updateSelectedUniversityInfo(id: Int, name: String, departments: [String]) {
+        selectedUniversityID = id
         selectedUniversityName = name
         selectedDepartmentList = departments
     }


### PR DESCRIPTION
## 💡 배경 및 개요
대학 등록, 수정 페이지가 학과 목록의 차이 빼고는 UI가 같아서 InputUniversityFeature 하나로 관리할 수 있도록 했어요.

Resolves: #386 

## 📃 작업내용

https://github.com/user-attachments/assets/6e27d323-560e-4c46-8a01-3505c933b8e1


대학 등록, 수정 페이지를 퍼블리싱 했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?