### PR TITLE
🔀 :: [#386] 대학 입력 페이지 기능 추가

### DIFF
--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -802,15 +802,29 @@ private func factoryd6018e98563de75a2ba4f47b58f8f304c97af4d5(_ component: Needle
     return LoginDependencyf4e78d0ad57be469bfd9Provider(appComponent: parent1(component) as! AppComponent)
 }
 private class InputUniversityDependencyd59283d5aa3af708a885Provider: InputUniversityDependency {
-
-
-    init() {
-
+    var createdUniversityUseCase: any CreatedUniversityUseCase {
+        return appComponent.createdUniversityUseCase
+    }
+    var modifyUniversityUseCase: any ModifyUniversityUseCase {
+        return appComponent.modifyUniversityUseCase
+    }
+    var deleteUniversityUseCase: any DeleteUniversityUseCase {
+        return appComponent.deleteUniversityUseCase
+    }
+    var createdDepartmentUseCase: any CreatedDepartmentUseCase {
+        return appComponent.createdDepartmentUseCase
+    }
+    var deleteDepartmentUseCase: any DeleteDepartmentUseCase {
+        return appComponent.deleteDepartmentUseCase
+    }
+    private let appComponent: AppComponent
+    init(appComponent: AppComponent) {
+        self.appComponent = appComponent
     }
 }
 /// ^->AppComponent->InputUniversityComponent
-private func factoryb6aa118932d97d72500ae3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
-    return InputUniversityDependencyd59283d5aa3af708a885Provider()
+private func factoryb6aa118932d97d72500af47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return InputUniversityDependencyd59283d5aa3af708a885Provider(appComponent: parent1(component) as! AppComponent)
 }
 private class LectureListDependencyf05b805b4d41a7643bcdProvider: LectureListDependency {
     var lectureListDetailFactory: any LectureListDetailFactory {
@@ -1235,7 +1249,11 @@ extension LoginComponent: Registration {
 }
 extension InputUniversityComponent: Registration {
     public func registerItems() {
-
+        keyPathToName[\InputUniversityDependency.createdUniversityUseCase] = "createdUniversityUseCase-any CreatedUniversityUseCase"
+        keyPathToName[\InputUniversityDependency.modifyUniversityUseCase] = "modifyUniversityUseCase-any ModifyUniversityUseCase"
+        keyPathToName[\InputUniversityDependency.deleteUniversityUseCase] = "deleteUniversityUseCase-any DeleteUniversityUseCase"
+        keyPathToName[\InputUniversityDependency.createdDepartmentUseCase] = "createdDepartmentUseCase-any CreatedDepartmentUseCase"
+        keyPathToName[\InputUniversityDependency.deleteDepartmentUseCase] = "deleteDepartmentUseCase-any DeleteDepartmentUseCase"
     }
 }
 extension LectureListComponent: Registration {
@@ -1506,7 +1524,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->ActivityListComponent", factory7177e6769ee69064a61bf47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->InputLectureComponent", factory622e14688d9803ec3c64f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->LoginComponent", factoryd6018e98563de75a2ba4f47b58f8f304c97af4d5)
-    registerProviderFactory("^->AppComponent->InputUniversityComponent", factoryb6aa118932d97d72500ae3b0c44298fc1c149afb)
+    registerProviderFactory("^->AppComponent->InputUniversityComponent", factoryb6aa118932d97d72500af47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->LectureListComponent", factorya2eac906a839dcacda45f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->PostDetailSettingComponent", factoryaacb19523586bb790cade3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->ActivityDetailComponent", factory7c395808ac9dfb8fb229f47b58f8f304c97af4d5)

--- a/App/Sources/Feature/InputOrganizationFeature/Source/InputOrganizationComponent.swift
+++ b/App/Sources/Feature/InputOrganizationFeature/Source/InputOrganizationComponent.swift
@@ -1,6 +1,6 @@
 import NeedleFoundation
-import SwiftUI
 import Service
+import SwiftUI
 
 public protocol InputOrganizationDependency: Dependency {
     var createdCompanyUseCase: any CreatedCompanyUseCase { get }

--- a/App/Sources/Feature/InputUniversityFeature/Source/Component/InputDepartmentView.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/Component/InputDepartmentView.swift
@@ -1,9 +1,29 @@
-//
-//  InputDepartmentVIew.swift
-//  Bitgouel
-//
-//  Created by 정윤서 on 7/27/24.
-//  Copyright © 2024 team.msg. All rights reserved.
-//
+import SwiftUI
 
-import Foundation
+struct InputDepartmentView: View {
+    @Environment(\.dismiss) var dismiss
+    @State var department: String = ""
+    let registeredDepartment: (String) -> Void
+
+    var body: some View {
+        VStack {
+            BitgouelTextField(
+                "학과 이름 입력",
+                text: $department
+            )
+            .padding(.top, 32)
+
+            Spacer()
+
+            ActivateButton(
+                text: "학과 등록",
+                buttonType: .add
+            ) {
+                registeredDepartment(department)
+                dismiss()
+            }
+        }
+        .padding(.horizontal, 28)
+        .navigationTitle("학과 등록")
+    }
+}

--- a/App/Sources/Feature/InputUniversityFeature/Source/Component/InputDepartmentView.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/Component/InputDepartmentView.swift
@@ -1,0 +1,9 @@
+//
+//  InputDepartmentVIew.swift
+//  Bitgouel
+//
+//  Created by 정윤서 on 7/27/24.
+//  Copyright © 2024 team.msg. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityComponent.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityComponent.swift
@@ -1,7 +1,14 @@
 import NeedleFoundation
+import Service
 import SwiftUI
 
-public protocol InputUniversityDependency: Dependency {}
+public protocol InputUniversityDependency: Dependency {
+    var createdUniversityUseCase: any CreatedUniversityUseCase { get }
+    var modifyUniversityUseCase: any ModifyUniversityUseCase { get }
+    var deleteUniversityUseCase: any DeleteUniversityUseCase { get }
+    var createdDepartmentUseCase: any CreatedDepartmentUseCase { get }
+    var deleteDepartmentUseCase: any DeleteDepartmentUseCase { get }
+}
 
 public final class InputUniversityComponent: Component<InputUniversityDependency>, InputUniversityFactory {
     public func makeView(
@@ -15,7 +22,12 @@ public final class InputUniversityComponent: Component<InputUniversityDependency
                 state: state,
                 universityName: universityName,
                 departmentList: departmentList,
-                universityID: universityID
+                universityID: universityID,
+                createdUniversityUseCase: dependency.createdUniversityUseCase,
+                modifyUniversityUseCase: dependency.modifyUniversityUseCase,
+                deleteUniversityUseCase: dependency.deleteUniversityUseCase,
+                createdDepartmentUseCase: dependency.createdDepartmentUseCase,
+                deleteDepartmentUseCase: dependency.deleteDepartmentUseCase
             )
         )
     }

--- a/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityView.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct InputUniversityView: View {
+    @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: InputUniversityViewModel
 
     init(viewModel: InputUniversityViewModel) {
@@ -26,6 +27,12 @@ struct InputUniversityView: View {
         }
         .padding(.horizontal, 28)
         .navigationTitle("대학 \(viewModel.state)")
+        .navigate(
+            to: InputDepartmentView.init(registeredDepartment: { department in
+                viewModel.createdDepartment(department: department)
+            }),
+            when: $viewModel.isPresentedInputDepartment
+        )
         .bitgouelAlert(
             title: "대학을 삭제하시겠습니까?",
             description: "",
@@ -42,7 +49,10 @@ struct InputUniversityView: View {
                     text: "삭제",
                     style: .error,
                     action: {
-                        viewModel.deleteUniversity()
+                        viewModel.deleteUniversity {
+                            viewModel.updateIsShowingDeleteAlert(isShowing: false)
+                            dismiss()
+                        }
                     }
                 )
             ]
@@ -78,7 +88,7 @@ struct InputUniversityView: View {
                             Spacer()
 
                             Button {
-                                viewModel.deleteDepartment(department: department ?? "")
+                                viewModel.deleteDepartment(index: index)
                             } label: {
                                 BitgouelAsset.Icons.minusFill.swiftUIImage
                                     .resizable()
@@ -128,7 +138,9 @@ struct InputUniversityView: View {
                     text: "수정 완료",
                     buttonType: .check
                 ) {
-                    viewModel.editUniversity()
+                    viewModel.modifyUniversity {
+                        dismiss()
+                    }
                 }
             }
         } else {
@@ -136,7 +148,9 @@ struct InputUniversityView: View {
                 text: "대학 등록",
                 buttonType: .add
             ) {
-                viewModel.createdUniversity()
+                viewModel.createdUniversity {
+                    dismiss()
+                }
             }
         }
     }

--- a/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityViewModel.swift
+++ b/App/Sources/Feature/InputUniversityFeature/Source/InputUniversityViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Service
 
 final class InputUniversityViewModel: BaseViewModel {
     @Published var universityName: String
@@ -8,16 +9,32 @@ final class InputUniversityViewModel: BaseViewModel {
     let state: String
     let universityID: Int
 
+    private let createdUniversityUseCase: any CreatedUniversityUseCase
+    private let modifyUniversityUseCase: any ModifyUniversityUseCase
+    private let deleteUniversityUseCase: any DeleteUniversityUseCase
+    private let createdDepartmentUseCase: any CreatedDepartmentUseCase
+    private let deleteDepartmentUseCase: any DeleteDepartmentUseCase
+
     init(
         state: String,
         universityName: String,
         departmentList: [String],
-        universityID: Int
+        universityID: Int,
+        createdUniversityUseCase: any CreatedUniversityUseCase,
+        modifyUniversityUseCase: any ModifyUniversityUseCase,
+        deleteUniversityUseCase: any DeleteUniversityUseCase,
+        createdDepartmentUseCase: any CreatedDepartmentUseCase,
+        deleteDepartmentUseCase: any DeleteDepartmentUseCase
     ) {
         self.state = state
         self.universityName = universityName
         self.departmentList = departmentList
         self.universityID = universityID
+        self.createdUniversityUseCase = createdUniversityUseCase
+        self.modifyUniversityUseCase = modifyUniversityUseCase
+        self.deleteUniversityUseCase = deleteUniversityUseCase
+        self.createdDepartmentUseCase = createdDepartmentUseCase
+        self.deleteDepartmentUseCase = deleteDepartmentUseCase
     }
 
     func updateIsShowingDeleteAlert(isShowing: Bool) {
@@ -28,20 +45,81 @@ final class InputUniversityViewModel: BaseViewModel {
         isPresentedInputDepartment = isPresented
     }
 
-    func editUniversity() {
-        #warning("대학 수정 기능 추가")
+    @MainActor
+    func modifyUniversity(_ success: @escaping () -> Void) {
+        Task {
+            do {
+                try await modifyUniversityUseCase(
+                    universityID: universityID,
+                    req: UniversityNameRequestDTO(universityName: universityName)
+                )
+
+                success()
+            } catch {
+                errorMessage = error.universityDomainErrorMessage()
+                isErrorOccurred = true
+            }
+        }
     }
 
-    func createdUniversity() {
-        #warning("대학 등록 기능 추가")
+    @MainActor
+    func createdUniversity(_ success: @escaping () -> Void) {
+        Task {
+            do {
+                try await createdUniversityUseCase(req: UniversityNameRequestDTO(universityName: universityName))
+
+                success()
+            } catch {
+                errorMessage = error.universityDomainErrorMessage()
+                isErrorOccurred = true
+            }
+        }
     }
 
-    func deleteUniversity() {
-        #warning("대학 삭제 기능 추가")
+    @MainActor
+    func deleteUniversity(_ success: @escaping () -> Void) {
+        Task {
+            do {
+                try await deleteUniversityUseCase(universityID: universityID)
+
+                success()
+            } catch {
+                errorMessage = error.universityDomainErrorMessage()
+                isErrorOccurred = true
+            }
+        }
     }
 
-    func deleteDepartment(department: String) {
-        guard department == "" else { return }
-        #warning("학과 삭제 기능 추가")
+    @MainActor
+    func deleteDepartment(index: Int) {
+        guard let department = departmentList[safe: index] else { return }
+
+        Task {
+            do {
+                try await deleteDepartmentUseCase(universityID: universityID, department: department)
+
+                departmentList.remove(at: index)
+            } catch {
+                errorMessage = error.universityDomainErrorMessage()
+                isErrorOccurred = true
+            }
+        }
+    }
+
+    @MainActor
+    func createdDepartment(department: String) {
+        Task {
+            do {
+                try await createdDepartmentUseCase(
+                    universityID: universityID,
+                    req: DepartmentRequestDTO(department: department)
+                )
+
+                departmentList.append(department)
+            } catch {
+                errorMessage = error.universityDomainErrorMessage()
+                isErrorOccurred = true
+            }
+        }
     }
 }

--- a/App/Sources/Feature/OrganizationListFeature/Source/OrganizationListComponent.swift
+++ b/App/Sources/Feature/OrganizationListFeature/Source/OrganizationListComponent.swift
@@ -1,6 +1,6 @@
 import NeedleFoundation
-import SwiftUI
 import Service
+import SwiftUI
 
 public protocol OrganizationListDependency: Dependency {
     var fetchCompanyListUseCase: any FetchCompanyListUseCase { get }

--- a/App/Sources/Feature/UniversityListFeature/Source/UniversityListComponent.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/UniversityListComponent.swift
@@ -1,6 +1,6 @@
 import NeedleFoundation
-import SwiftUI
 import Service
+import SwiftUI
 
 public protocol UniversityListDependency: Dependency {
     var fetchUniversityListUseCase: any FetchUniversityListUseCase { get }

--- a/App/Sources/Feature/UniversityListFeature/Source/UniversityListView.swift
+++ b/App/Sources/Feature/UniversityListFeature/Source/UniversityListView.swift
@@ -27,7 +27,7 @@ struct UniversityListView: View {
                         )
                         .onTapGesture {
                             viewModel.updateSelectedUniversityInfo(
-                                id: university.universityID, 
+                                id: university.universityID,
                                 name: university.universityName,
                                 departments: university.departments
                             )
@@ -49,6 +49,7 @@ struct UniversityListView: View {
             ) {
                 viewModel.updateState(state: "등록")
                 viewModel.updateIsPresentedInputUniversityPage(isPresented: true)
+                viewModel.updateIsShowingUniversityDetailBottomSheet(isShowing: false)
             }
         }
         .padding(.horizontal, 28)
@@ -84,6 +85,7 @@ struct UniversityListView: View {
             } editAction: {
                 viewModel.updateState(state: "수정")
                 viewModel.updateIsPresentedInputUniversityPage(isPresented: true)
+                viewModel.updateIsShowingUniversityDetailBottomSheet(isShowing: false)
             }
         }
         .navigate(

--- a/App/Sources/Utils/Extensions/Error+DomainErrorMessage.swift
+++ b/App/Sources/Utils/Extensions/Error+DomainErrorMessage.swift
@@ -83,4 +83,10 @@ extension Error {
             return companyDomainError.errorDescription ?? unknownErrorMessage
         } else { return unknownErrorMessage }
     }
+
+    func universityDomainErrorMessage() -> String {
+        if let universityDomainError = self as? UniversityDomainError {
+            return universityDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
 }

--- a/Service/Sources/Data/DataSource/University/RemoteUniversityDataSourceImpl.swift
+++ b/Service/Sources/Data/DataSource/University/RemoteUniversityDataSourceImpl.swift
@@ -9,19 +9,19 @@ public final class RemoteUniversityDataSourceImpl: BaseRemoteDataSource<Universi
         try await request(.createdUniversity(req: req))
     }
 
-    public func modifyUniversity(universityID: String, req: UniversityNameRequestDTO) async throws {
+    public func modifyUniversity(universityID: Int, req: UniversityNameRequestDTO) async throws {
         try await request(.modifyUniversity(universityID: universityID, req: req))
     }
 
-    public func deleteUniversity(universityID: String) async throws {
+    public func deleteUniversity(universityID: Int) async throws {
         try await request(.deleteUniversity(universityID: universityID))
     }
 
-    public func createdDepartment(universityID: String, req: DepartmentRequestDTO) async throws {
+    public func createdDepartment(universityID: Int, req: DepartmentRequestDTO) async throws {
         try await request(.createdDepartment(universityID: universityID, req: req))
     }
 
-    public func deleteDepartment(universityID: String, department: String) async throws {
+    public func deleteDepartment(universityID: Int, department: String) async throws {
         try await request(.deleteDepartment(universityID: universityID, department: department))
     }
 }

--- a/Service/Sources/Data/Repository/University/UniversityRepositoryImpl.swift
+++ b/Service/Sources/Data/Repository/University/UniversityRepositoryImpl.swift
@@ -15,19 +15,19 @@ public struct UniversityRepositoryImpl: UniversityRepository {
         try await remoteUniversityDataSource.createdUniversity(req: req)
     }
 
-    public func modifyUniversity(universityID: String, req: UniversityNameRequestDTO) async throws {
+    public func modifyUniversity(universityID: Int, req: UniversityNameRequestDTO) async throws {
         try await remoteUniversityDataSource.modifyUniversity(universityID: universityID, req: req)
     }
 
-    public func deleteUniversity(universityID: String) async throws {
+    public func deleteUniversity(universityID: Int) async throws {
         try await remoteUniversityDataSource.deleteUniversity(universityID: universityID)
     }
 
-    public func createdDepartment(universityID: String, req: DepartmentRequestDTO) async throws {
+    public func createdDepartment(universityID: Int, req: DepartmentRequestDTO) async throws {
         try await remoteUniversityDataSource.createdDepartment(universityID: universityID, req: req)
     }
 
-    public func deleteDepartment(universityID: String, department: String) async throws {
+    public func deleteDepartment(universityID: Int, department: String) async throws {
         try await remoteUniversityDataSource.deleteDepartment(universityID: universityID, department: department)
     }
 }

--- a/Service/Sources/Data/UseCase/University/CreatedDepartmentUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/University/CreatedDepartmentUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct CreatedDepartmentUseCaseImpl: CreatedDepartmentUseCase {
         self.universityRepository = universityRepository
     }
 
-    public func callAsFunction(universityID: String, req: DepartmentRequestDTO) async throws {
+    public func callAsFunction(universityID: Int, req: DepartmentRequestDTO) async throws {
         try await universityRepository.createdDepartment(universityID: universityID, req: req)
     }
 }

--- a/Service/Sources/Data/UseCase/University/DeleteDepartmentUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/University/DeleteDepartmentUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct DeleteDepartmentUseCaseImpl: DeleteDepartmentUseCase {
         self.universityRepository = universityRepository
     }
 
-    public func callAsFunction(universityID: String, department: String) async throws {
+    public func callAsFunction(universityID: Int, department: String) async throws {
         try await universityRepository.deleteDepartment(universityID: universityID, department: department)
     }
 }

--- a/Service/Sources/Data/UseCase/University/DeleteUniversityUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/University/DeleteUniversityUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct DeleteUniversityUseCaseImpl: DeleteUniversityUseCase {
         self.universityRepository = universityRepository
     }
 
-    public func callAsFunction(universityID: String) async throws {
+    public func callAsFunction(universityID: Int) async throws {
         try await universityRepository.deleteUniversity(universityID: universityID)
     }
 }

--- a/Service/Sources/Data/UseCase/University/ModifyUniversityUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/University/ModifyUniversityUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct ModifyUniversityUseCaseImpl: ModifyUniversityUseCase {
         self.universityRepository = universityRepository
     }
 
-    public func callAsFunction(universityID: String, req: UniversityNameRequestDTO) async throws {
+    public func callAsFunction(universityID: Int, req: UniversityNameRequestDTO) async throws {
         try await universityRepository.modifyUniversity(universityID: universityID, req: req)
     }
 }

--- a/Service/Sources/Domain/UniversityDomain/API/UniversityAPI.swift
+++ b/Service/Sources/Domain/UniversityDomain/API/UniversityAPI.swift
@@ -4,10 +4,10 @@ import Moya
 public enum UniversityAPI {
     case fetchUniversityList
     case createdUniversity(req: UniversityNameRequestDTO)
-    case modifyUniversity(universityID: String, req: UniversityNameRequestDTO)
-    case deleteUniversity(universityID: String)
-    case createdDepartment(universityID: String, req: DepartmentRequestDTO)
-    case deleteDepartment(universityID: String, department: String)
+    case modifyUniversity(universityID: Int, req: UniversityNameRequestDTO)
+    case deleteUniversity(universityID: Int)
+    case createdDepartment(universityID: Int, req: DepartmentRequestDTO)
+    case deleteDepartment(universityID: Int, department: String)
 }
 
 extension UniversityAPI: BitgouelAPI {

--- a/Service/Sources/Domain/UniversityDomain/DTO/Request/DepartmentRequestDTO.swift
+++ b/Service/Sources/Domain/UniversityDomain/DTO/Request/DepartmentRequestDTO.swift
@@ -2,4 +2,8 @@ import Foundation
 
 public struct DepartmentRequestDTO: Encodable {
     public let department: String
+
+    public init(department: String) {
+        self.department = department
+    }
 }

--- a/Service/Sources/Domain/UniversityDomain/DTO/Request/UniversityNameRequestDTO.swift
+++ b/Service/Sources/Domain/UniversityDomain/DTO/Request/UniversityNameRequestDTO.swift
@@ -2,4 +2,8 @@ import Foundation
 
 public struct UniversityNameRequestDTO: Encodable {
     public let universityName: String
+
+    public init(universityName: String) {
+        self.universityName = universityName
+    }
 }

--- a/Service/Sources/Domain/UniversityDomain/DataSource/RemoteUniversityDataSource.swift
+++ b/Service/Sources/Domain/UniversityDomain/DataSource/RemoteUniversityDataSource.swift
@@ -3,8 +3,8 @@ import Foundation
 public protocol RemoteUniversityDataSource: BaseRemoteDataSource<UniversityAPI> {
     func fetchUniversityList() async throws -> [UniversityInfoEntity]
     func createdUniversity(req: UniversityNameRequestDTO) async throws
-    func modifyUniversity(universityID: String, req: UniversityNameRequestDTO) async throws
-    func deleteUniversity(universityID: String) async throws
-    func createdDepartment(universityID: String, req: DepartmentRequestDTO) async throws
-    func deleteDepartment(universityID: String, department: String) async throws
+    func modifyUniversity(universityID: Int, req: UniversityNameRequestDTO) async throws
+    func deleteUniversity(universityID: Int) async throws
+    func createdDepartment(universityID: Int, req: DepartmentRequestDTO) async throws
+    func deleteDepartment(universityID: Int, department: String) async throws
 }

--- a/Service/Sources/Domain/UniversityDomain/Repository/UniversityRepository.swift
+++ b/Service/Sources/Domain/UniversityDomain/Repository/UniversityRepository.swift
@@ -3,8 +3,8 @@ import Foundation
 public protocol UniversityRepository {
     func fetchUniversityList() async throws -> [UniversityInfoEntity]
     func createdUniversity(req: UniversityNameRequestDTO) async throws
-    func modifyUniversity(universityID: String, req: UniversityNameRequestDTO) async throws
-    func deleteUniversity(universityID: String) async throws
-    func createdDepartment(universityID: String, req: DepartmentRequestDTO) async throws
-    func deleteDepartment(universityID: String, department: String) async throws
+    func modifyUniversity(universityID: Int, req: UniversityNameRequestDTO) async throws
+    func deleteUniversity(universityID: Int) async throws
+    func createdDepartment(universityID: Int, req: DepartmentRequestDTO) async throws
+    func deleteDepartment(universityID: Int, department: String) async throws
 }

--- a/Service/Sources/Domain/UniversityDomain/UseCase/CreatedDepartmentUseCase.swift
+++ b/Service/Sources/Domain/UniversityDomain/UseCase/CreatedDepartmentUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol CreatedDepartmentUseCase {
-    func callAsFunction(universityID: String, req: DepartmentRequestDTO) async throws
+    func callAsFunction(universityID: Int, req: DepartmentRequestDTO) async throws
 }

--- a/Service/Sources/Domain/UniversityDomain/UseCase/DeleteDepartmentUseCase.swift
+++ b/Service/Sources/Domain/UniversityDomain/UseCase/DeleteDepartmentUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol DeleteDepartmentUseCase {
-    func callAsFunction(universityID: String, department: String) async throws
+    func callAsFunction(universityID: Int, department: String) async throws
 }

--- a/Service/Sources/Domain/UniversityDomain/UseCase/DeleteUniversityUseCase.swift
+++ b/Service/Sources/Domain/UniversityDomain/UseCase/DeleteUniversityUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol DeleteUniversityUseCase {
-    func callAsFunction(universityID: String) async throws
+    func callAsFunction(universityID: Int) async throws
 }

--- a/Service/Sources/Domain/UniversityDomain/UseCase/ModifyUniversityUseCase.swift
+++ b/Service/Sources/Domain/UniversityDomain/UseCase/ModifyUniversityUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol ModifyUniversityUseCase {
-    func callAsFunction(universityID: String, req: UniversityNameRequestDTO) async throws
+    func callAsFunction(universityID: Int, req: UniversityNameRequestDTO) async throws
 }


### PR DESCRIPTION
## 💡 배경 및 개요
대학 등록 페이지에 대학 삭제, 수정, 등록, 학과 생성, 삭제 기능을 추가했어요.

Resolves: #386 

## 📃 작업내용
- 대학 등록
- 대학 삭제
- 대학 수정
- 학과 생성
- 학과 삭제
위 기능들을 추가했어요.

- universityDomainErrorMessage() Util을 추가했어요!

## 🙋‍♂️ 리뷰노트
- UniversityID의 Type이 String으로 되어있어서 Int로 변경했어요!

- 대학 목록 페이지 -> 대학 상세 BottomSheet -> 대학 수정 페이지 이동 후 다시 대학 목록 페이지로 이동했을 때
 BottomSheet가 내려가지 않아서 삭제된 대학의 상세 BottomSheet가 보이게 되거나, 수정된 내용이 적용되지 않은 상세 BottomSheet가 보이게 되는 문제가 발생해서 대학 수정 페이지로 이동했을 때 BottomSheet가 내려가도록 수정했어요.

- 학과 생성, 삭제 시 서버로 다시 리스트 조회 요청을 보내 학과 List를 받기에는 불필요한 요청이 많아질 것 같고, 대학이 많아졌을 때 선택한 대학의 id를 찾는 과정이 복잡해질 것 같다고 판단해서 처음 서버에서 받은 DepartmentList에 클라이언트에서 append 및 remove를 하도록 진행했어요! 감안하고 리뷰해주세요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?