### PR TITLE
🔀 :: [#391] 학교 정보 입력 기능 추가

### DIFF
--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -536,15 +536,23 @@ private func factory4d07a7e30330c03d5d63f47b58f8f304c97af4d5(_ component: Needle
     return WithdrawUserListDependencyc576fefb2eff9e703c66Provider(appComponent: parent1(component) as! AppComponent)
 }
 private class InputSchoolDependencye8d4bffe76e2533005e2Provider: InputSchoolDependency {
-
-
-    init() {
-
+    var createdSchoolUseCase: any CreatedSchoolUseCase {
+        return appComponent.createdSchoolUseCase
+    }
+    var modifySchoolUseCase: any ModifySchoolUseCase {
+        return appComponent.modifySchoolUseCase
+    }
+    var deleteSchoolUseCase: any DeleteSchoolUseCase {
+        return appComponent.deleteSchoolUseCase
+    }
+    private let appComponent: AppComponent
+    init(appComponent: AppComponent) {
+        self.appComponent = appComponent
     }
 }
 /// ^->AppComponent->InputSchoolComponent
-private func factorya02470c933733e398aeee3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
-    return InputSchoolDependencye8d4bffe76e2533005e2Provider()
+private func factorya02470c933733e398aeef47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return InputSchoolDependencye8d4bffe76e2533005e2Provider(appComponent: parent1(component) as! AppComponent)
 }
 private class FindPasswordDependency542eacce769b9dc25904Provider: FindPasswordDependency {
     var sendEmailCertificationLinkUseCase: any SendEmailCertificationLinkUseCase {
@@ -1165,7 +1173,9 @@ extension WithdrawUserListComponent: Registration {
 }
 extension InputSchoolComponent: Registration {
     public func registerItems() {
-
+        keyPathToName[\InputSchoolDependency.createdSchoolUseCase] = "createdSchoolUseCase-any CreatedSchoolUseCase"
+        keyPathToName[\InputSchoolDependency.modifySchoolUseCase] = "modifySchoolUseCase-any ModifySchoolUseCase"
+        keyPathToName[\InputSchoolDependency.deleteSchoolUseCase] = "deleteSchoolUseCase-any DeleteSchoolUseCase"
     }
 }
 extension FindPasswordComponent: Registration {
@@ -1531,7 +1541,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->ClubDetailComponent", factory1559652f8e80cfa88d06f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->SuccessSignUpComponent", factorybf219b153b668170161de3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->WithdrawUserListComponent", factory4d07a7e30330c03d5d63f47b58f8f304c97af4d5)
-    registerProviderFactory("^->AppComponent->InputSchoolComponent", factorya02470c933733e398aeee3b0c44298fc1c149afb)
+    registerProviderFactory("^->AppComponent->InputSchoolComponent", factorya02470c933733e398aeef47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->FindPasswordComponent", factory15775d8436b06b9741d1f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->LectureApplicantListComponent", factory78a87c10d14f7bbaaa9df47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->UserListComponent", factorycf08383b935d2e18f4c7f47b58f8f304c97af4d5)

--- a/App/Sources/Feature/InputSchoolFeature/Source/Component/CreatedSchoolSuccessView.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/Component/CreatedSchoolSuccessView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct CreatedClubSuccessView: View {
+struct CreatedSchoolSuccessView: View {
     let dismiss: () -> Void
 
     var body: some View {

--- a/App/Sources/Feature/InputSchoolFeature/Source/Component/CreatedSchoolSuccessView.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/Component/CreatedSchoolSuccessView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct CreatedSchoolSuccessView: View {
-    let dismiss: () -> Void
-
     var body: some View {
         VStack {
             BitgouelAsset.Icons.check.swiftUIImage
@@ -15,14 +13,15 @@ struct CreatedSchoolSuccessView: View {
             Text("새 학교를 등록했습니다.")
                 .bitgouelFont(.text3, color: .greyscale(.g4))
 
+            Spacer()
+
             BitgouelButton(
                 text: "돌아가기"
             ) {
-                dismiss()
+                
             }
             .cornerRadius(8)
             .padding(.horizontal, 28)
-            .padding(.bottom, 46)
         }
         .navigationBarBackButtonHidden(true)
     }

--- a/App/Sources/Feature/InputSchoolFeature/Source/Component/CreatedSchoolSuccessView.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/Component/CreatedSchoolSuccessView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct CreatedClubSuccessView: View {
+    let dismiss: () -> Void
+
+    var body: some View {
+        VStack {
+            BitgouelAsset.Icons.check.swiftUIImage
+                .padding(.top, 233)
+
+            Text("학교 등록 완료")
+                .bitgouelFont(.title2)
+                .padding(.top, 24)
+
+            Text("새 학교를 등록했습니다.")
+                .bitgouelFont(.text3, color: .greyscale(.g4))
+
+            BitgouelButton(
+                text: "돌아가기"
+            ) {
+                dismiss()
+            }
+            .cornerRadius(8)
+            .padding(.horizontal, 28)
+            .padding(.bottom, 46)
+        }
+        .navigationBarBackButtonHidden(true)
+    }
+}

--- a/App/Sources/Feature/InputSchoolFeature/Source/Component/SchoolLineBottomSheet.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/Component/SchoolLineBottomSheet.swift
@@ -36,15 +36,19 @@ public struct SchoolLineBottomSheet: View {
                                 text: line.display(),
                                 font: .text2
                             )
-
+                            .foregroundColor(.black)
+                            
                             Spacer()
-
+                            
                             BitgouelRadioButton(
                                 isSelected: Binding(
                                     get: { line == selectedLine },
                                     set: { _ in selectLine(line) }
                                 )
                             )
+                        }
+                        .buttonWrapper {
+                            selectLine(line)
                         }
                         .padding(.vertical, 24)
                     }

--- a/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolComponent.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolComponent.swift
@@ -9,7 +9,10 @@ public protocol InputSchoolDependency: Dependency {
 }
 
 public final class InputSchoolComponent: Component<InputSchoolDependency>, InputSchoolFactory {
-    public func makeView(state: String, schoolInfo: SchoolDetailInfoModel) -> some View {
+    public func makeView(
+        state: String,
+        schoolInfo: SchoolDetailInfoModel
+    ) -> some View {
         InputSchoolView(
             viewModel: .init(
                 state: state,

--- a/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolComponent.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolComponent.swift
@@ -1,14 +1,22 @@
 import NeedleFoundation
 import SwiftUI
+import Service
 
-public protocol InputSchoolDependency: Dependency {}
+public protocol InputSchoolDependency: Dependency {
+    var createdSchoolUseCase: any CreatedSchoolUseCase { get }
+    var modifySchoolUseCase: any ModifySchoolUseCase { get }
+    var deleteSchoolUseCase: any DeleteSchoolUseCase { get }
+}
 
 public final class InputSchoolComponent: Component<InputSchoolDependency>, InputSchoolFactory {
     public func makeView(state: String, schoolInfo: SchoolDetailInfoModel) -> some View {
         InputSchoolView(
             viewModel: .init(
                 state: state,
-                schoolInfo: schoolInfo
+                schoolInfo: schoolInfo,
+                createdSchoolUseCase: dependency.createdSchoolUseCase,
+                modifySchoolUseCase: dependency.modifySchoolUseCase,
+                deleteSchoolUseCase: dependency.deleteSchoolUseCase
             )
         )
     }

--- a/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolView.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolView.swift
@@ -16,10 +16,20 @@ struct InputSchoolView: View {
                     Button {
                         viewModel.updateIsShowingImagePicker(isShowing: true)
                     } label: {
-                        LazyImage(source: viewModel.schoolInfo.logoImageURL) { state in
+                        LazyImage(source: viewModel.logoImageURL) { state in
                             if let image = state.image {
-                                image
-                                    .resizingMode(.aspectFit)
+                                ZStack {
+                                    image
+                                        .resizingMode(.aspectFit)
+                                        .cornerRadius(8, corners: .allCorners)
+                                        .blur(radius: 1)
+
+                                    BitgouelAsset.Icons.add.swiftUIImage
+                                        .resizable()
+                                        .renderingMode(.template)
+                                        .foregroundColor(.white)
+                                        .frame(width: 24, height: 24)
+                                }
                             } else {
                                 schoolLogoImage()
                             }
@@ -128,6 +138,7 @@ struct InputSchoolView: View {
                     action: {
                         viewModel.deleteSchool {
                             viewModel.updateIsShowingDeleteAlert(isShowing: false)
+                            viewModel.updateIsShowingLineBottomSheet(isShowing: false)
                             dismiss()
                         }
                     }
@@ -138,6 +149,13 @@ struct InputSchoolView: View {
             text: viewModel.errorMessage,
             isShowing: $viewModel.isErrorOccurred
         )
+        .navigate(
+            to: CreatedSchoolSuccessView { dismiss() },
+            when: $viewModel.isPresentedSuccessView
+        )
+        .onChange(of: viewModel.image) { _ in
+            viewModel.logoImageURL = nil
+        }
     }
     
     @ViewBuilder
@@ -157,6 +175,7 @@ struct InputSchoolView: View {
                 ) {
                     viewModel.modifySchool {
                         dismiss()
+                        viewModel.updateIsShowingLineBottomSheet(isShowing: false)
                     }
                 }
             }
@@ -164,6 +183,7 @@ struct InputSchoolView: View {
             BitgouelButton(text: "다음으로", style: .primary) {
                 viewModel.createdSchool {
                     viewModel.updateIsPresentedSuccessView(isPresented: true)
+                    viewModel.updateIsShowingLineBottomSheet(isShowing: false)
                 }
             }
         }
@@ -175,7 +195,6 @@ struct InputSchoolView: View {
             ZStack {
                 image
                     .resizable()
-                    .frame(width: 80, height: 80)
                     .cornerRadius(8, corners: .allCorners)
                     .blur(radius: 1)
                 

--- a/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolView.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolView.swift
@@ -85,6 +85,8 @@ struct InputSchoolView: View {
                     }
                 }
             }
+
+            Spacer(minLength: 50)
         }
         .overlay(alignment: .bottom) {
             renderFormButton()
@@ -131,6 +133,10 @@ struct InputSchoolView: View {
                     }
                 )
             ]
+        )
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
         )
     }
     

--- a/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolView.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolView.swift
@@ -138,7 +138,6 @@ struct InputSchoolView: View {
                     action: {
                         viewModel.deleteSchool {
                             viewModel.updateIsShowingDeleteAlert(isShowing: false)
-                            viewModel.updateIsShowingLineBottomSheet(isShowing: false)
                             dismiss()
                         }
                     }
@@ -150,7 +149,7 @@ struct InputSchoolView: View {
             isShowing: $viewModel.isErrorOccurred
         )
         .navigate(
-            to: CreatedSchoolSuccessView { dismiss() },
+            to: CreatedSchoolSuccessView(),
             when: $viewModel.isPresentedSuccessView
         )
         .onChange(of: viewModel.image) { _ in
@@ -183,7 +182,6 @@ struct InputSchoolView: View {
             BitgouelButton(text: "다음으로", style: .primary) {
                 viewModel.createdSchool {
                     viewModel.updateIsPresentedSuccessView(isPresented: true)
-                    viewModel.updateIsShowingLineBottomSheet(isShowing: false)
                 }
             }
         }

--- a/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolViewModel.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolViewModel.swift
@@ -118,8 +118,26 @@ final class InputSchoolViewModel: BaseViewModel {
     }
 
     @MainActor
-    func modifySchool(_ success: @escaping () -> Void) {
-        #warning("학교 수정 기능 추가")
-        success()
-    }
+        func modifySchool(_ success: @escaping () -> Void) {
+            guard let line = selectedLine else { return }
+
+            Task {
+                do {
+                    try await modifySchoolUseCase(
+                        schoolID: schoolInfo.schoolID,
+                        logoImage: selectedUIImage?.jpegData(compressionQuality: 0.2) ?? .init(),
+                        req: InputSchoolInfoRequestDTO(
+                            schoolName: schoolName,
+                            line: line.rawValue,
+                            departments: departmentList
+                        )
+                    )
+
+                    success()
+                } catch {
+                    errorMessage = error.schoolDomainErrorMessage()
+                    isErrorOccurred = true
+                }
+            }
+        }
 }

--- a/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolViewModel.swift
+++ b/App/Sources/Feature/InputSchoolFeature/Source/InputSchoolViewModel.swift
@@ -105,8 +105,16 @@ final class InputSchoolViewModel: BaseViewModel {
 
     @MainActor
     func deleteSchool(_ success: @escaping () -> Void) {
-        #warning("학교 삭제 기능 추가")
-        success()
+        Task {
+            do {
+                try await deleteSchoolUseCase(schoolID: schoolInfo.schoolID)
+                
+                success()
+            } catch {
+                errorMessage = error.schoolDomainErrorMessage()
+                isErrorOccurred = true
+            }
+        }
     }
 
     @MainActor

--- a/App/Sources/Feature/SchoolListFeature/Source/SchoolListView.swift
+++ b/App/Sources/Feature/SchoolListFeature/Source/SchoolListView.swift
@@ -58,6 +58,7 @@ struct SchoolListView: View {
                 text: "새로운 학교 등록",
                 buttonType: .add
             ) {
+                viewModel.updateIsShowingSchoolDetailBottomSheet(isShowing: false)
                 viewModel.updateIsPresentedInputSchoolInfoView(isPresented: true, state: "등록")
             }
         }
@@ -82,6 +83,7 @@ struct SchoolListView: View {
             SchoolDetailBottomSheet(
                 schoolInfo: viewModel.schoolInfo
             ) {
+                viewModel.updateIsShowingSchoolDetailBottomSheet(isShowing: false)
                 viewModel.updateIsPresentedInputSchoolInfoView(isPresented: true, state: "수정")
             } cancel: { cancel in
                 viewModel.updateIsShowingSchoolDetailBottomSheet(isShowing: cancel)
@@ -98,7 +100,10 @@ struct SchoolListView: View {
             }
         }
         .navigate(
-            to: inputSchoolFactory.makeView(state: viewModel.state, schoolInfo: viewModel.schoolInfo).eraseToAnyView(),
+            to: inputSchoolFactory.makeView(
+                state: viewModel.state,
+                schoolInfo: viewModel.schoolInfo
+            ).eraseToAnyView(),
             when: $viewModel.isPresentedInputSchoolInfoView
         )
     }

--- a/App/Sources/Utils/Extensions/Error+DomainErrorMessage.swift
+++ b/App/Sources/Utils/Extensions/Error+DomainErrorMessage.swift
@@ -89,4 +89,10 @@ extension Error {
             return universityDomainError.errorDescription ?? unknownErrorMessage
         } else { return unknownErrorMessage }
     }
+
+    func schoolDomainErrorMessage() -> String {
+        if let schoolDomainError = self as? SchoolDomainError {
+            return schoolDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
 }

--- a/Service/Sources/Data/DataSource/School/RemoteSchoolDataSourceImpl.swift
+++ b/Service/Sources/Data/DataSource/School/RemoteSchoolDataSourceImpl.swift
@@ -9,12 +9,12 @@ public final class RemoteSchoolDataSourceImpl: BaseRemoteDataSource<SchoolAPI>, 
         try await request(.fetchAllSchoolName, dto: FetchSchoolNameResponseDTO.self).toDomain()
     }
 
-    public func createdSchool(req: InputSchoolInfoRequestDTO) async throws {
-        try await request(.createdSchool(req: req))
+    public func createdSchool(logoImage: Data, req: InputSchoolInfoRequestDTO) async throws {
+        try await request(.createdSchool(logoImage: logoImage, req: req))
     }
 
-    public func modifySchool(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws {
-        try await request(.modifySchool(schoolID: schoolID, req: req))
+    public func modifySchool(schoolID: Int, logoImage: Data, req: InputSchoolInfoRequestDTO) async throws {
+        try await request(.modifySchool(schoolID: schoolID, logoImage: logoImage, req: req))
     }
 
     public func deleteSchool(schoolID: Int) async throws {

--- a/Service/Sources/Data/DataSource/School/RemoteSchoolDataSourceImpl.swift
+++ b/Service/Sources/Data/DataSource/School/RemoteSchoolDataSourceImpl.swift
@@ -9,11 +9,11 @@ public final class RemoteSchoolDataSourceImpl: BaseRemoteDataSource<SchoolAPI>, 
         try await request(.fetchAllSchoolName, dto: FetchSchoolNameResponseDTO.self).toDomain()
     }
 
-    public func createdSchool(req: CreatedSchoolRequestDTO) async throws {
+    public func createdSchool(req: InputSchoolInfoRequestDTO) async throws {
         try await request(.createdSchool(req: req))
     }
 
-    public func modifySchool(schoolID: Int, req: ModifySchoolRequestDTO) async throws {
+    public func modifySchool(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws {
         try await request(.modifySchool(schoolID: schoolID, req: req))
     }
 

--- a/Service/Sources/Data/Repository/School/SchoolRepositoryImpl.swift
+++ b/Service/Sources/Data/Repository/School/SchoolRepositoryImpl.swift
@@ -15,11 +15,11 @@ public struct SchoolRepositoryImpl: SchoolRepository {
         try await remoteSchoolDataSource.fetchAllSchoolName()
     }
 
-    public func createdSchool(req: CreatedSchoolRequestDTO) async throws {
+    public func createdSchool(req: InputSchoolInfoRequestDTO) async throws {
         try await remoteSchoolDataSource.createdSchool(req: req)
     }
 
-    public func modifySchool(schoolID: Int, req: ModifySchoolRequestDTO) async throws {
+    public func modifySchool(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws {
         try await remoteSchoolDataSource.modifySchool(schoolID: schoolID, req: req)
     }
 

--- a/Service/Sources/Data/Repository/School/SchoolRepositoryImpl.swift
+++ b/Service/Sources/Data/Repository/School/SchoolRepositoryImpl.swift
@@ -15,12 +15,12 @@ public struct SchoolRepositoryImpl: SchoolRepository {
         try await remoteSchoolDataSource.fetchAllSchoolName()
     }
 
-    public func createdSchool(req: InputSchoolInfoRequestDTO) async throws {
-        try await remoteSchoolDataSource.createdSchool(req: req)
+    public func createdSchool(logoImage: Data, req: InputSchoolInfoRequestDTO) async throws {
+        try await remoteSchoolDataSource.createdSchool(logoImage: logoImage, req: req)
     }
 
-    public func modifySchool(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws {
-        try await remoteSchoolDataSource.modifySchool(schoolID: schoolID, req: req)
+    public func modifySchool(schoolID: Int, logoImage: Data, req: InputSchoolInfoRequestDTO) async throws {
+        try await remoteSchoolDataSource.modifySchool(schoolID: schoolID, logoImage: logoImage, req: req)
     }
 
     public func deleteSchool(schoolID: Int) async throws {

--- a/Service/Sources/Data/UseCase/School/CreatedSchoolUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/School/CreatedSchoolUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct CreatedSchoolUseCaseImpl: CreatedSchoolUseCase {
         self.schoolRepository = schoolRepository
     }
 
-    public func callAsFunction(req: CreatedSchoolRequestDTO) async throws {
+    public func callAsFunction(req: InputSchoolInfoRequestDTO) async throws {
         try await schoolRepository.createdSchool(req: req)
     }
 }

--- a/Service/Sources/Data/UseCase/School/CreatedSchoolUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/School/CreatedSchoolUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct CreatedSchoolUseCaseImpl: CreatedSchoolUseCase {
         self.schoolRepository = schoolRepository
     }
 
-    public func callAsFunction(req: InputSchoolInfoRequestDTO) async throws {
-        try await schoolRepository.createdSchool(req: req)
+    public func callAsFunction(logoImage: Data, req: InputSchoolInfoRequestDTO) async throws {
+        try await schoolRepository.createdSchool(logoImage: logoImage, req: req)
     }
 }

--- a/Service/Sources/Data/UseCase/School/ModifySchoolUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/School/ModifySchoolUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct ModifySchoolUseCaseImpl: ModifySchoolUseCase {
         self.schoolRepository = schoolRepository
     }
 
-    public func callAsFunction(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws {
-        try await schoolRepository.modifySchool(schoolID: schoolID, req: req)
+    public func callAsFunction(schoolID: Int, logoImage: Data, req: InputSchoolInfoRequestDTO) async throws {
+        try await schoolRepository.modifySchool(schoolID: schoolID, logoImage: logoImage, req: req)
     }
 }

--- a/Service/Sources/Data/UseCase/School/ModifySchoolUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/School/ModifySchoolUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct ModifySchoolUseCaseImpl: ModifySchoolUseCase {
         self.schoolRepository = schoolRepository
     }
 
-    public func callAsFunction(schoolID: Int, req: ModifySchoolRequestDTO) async throws {
+    public func callAsFunction(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws {
         try await schoolRepository.modifySchool(schoolID: schoolID, req: req)
     }
 }

--- a/Service/Sources/Domain/SchoolDoamin/API/SchoolAPI.swift
+++ b/Service/Sources/Domain/SchoolDoamin/API/SchoolAPI.swift
@@ -57,7 +57,12 @@ extension SchoolAPI: BitgouelAPI {
 
         case let .createdSchool(logoImage, req),
              let .modifySchool(_, logoImage, req):
-            let imageData = MultipartFormData(provider: .data(logoImage), name: "logoImage")
+            let imageData = MultipartFormData(
+                provider: .data(logoImage),
+                name: "logoImage",
+                fileName: "\(req.schoolName).jpg",
+                mimeType: "image/jpg"
+            )
             let params: [String: Any] = [
                 "name": req.schoolName,
                 "line": req.line,

--- a/Service/Sources/Domain/SchoolDoamin/DTO/Request/CreatedSchoolRequestDTO.swift
+++ b/Service/Sources/Domain/SchoolDoamin/DTO/Request/CreatedSchoolRequestDTO.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-public struct CreatedSchoolRequestDTO: Encodable {
-    public let schoolName: String
-    public let line: LineType
-    public let department: [String]
-    public let logoImage: Data
-}

--- a/Service/Sources/Domain/SchoolDoamin/DTO/Request/InputSchoolInfoRequestDTO.swift
+++ b/Service/Sources/Domain/SchoolDoamin/DTO/Request/InputSchoolInfoRequestDTO.swift
@@ -2,19 +2,16 @@ import Foundation
 
 public struct InputSchoolInfoRequestDTO: Encodable {
     public let schoolName: String
-    public let line: LineType
+    public let line: String
     public let departments: [String]
-    public let logoImage: Data
 
     public init(
         schoolName: String,
-        line: LineType,
-        departments: [String],
-        logoImage: Data
+        line: String,
+        departments: [String]
     ) {
         self.schoolName = schoolName
         self.line = line
         self.departments = departments
-        self.logoImage = logoImage
     }
 }

--- a/Service/Sources/Domain/SchoolDoamin/DTO/Request/InputSchoolInfoRequestDTO.swift
+++ b/Service/Sources/Domain/SchoolDoamin/DTO/Request/InputSchoolInfoRequestDTO.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public struct InputSchoolInfoRequestDTO: Encodable {
+    public let schoolName: String
+    public let line: LineType
+    public let departments: [String]
+    public let logoImage: Data
+
+    public init(
+        schoolName: String,
+        line: LineType,
+        departments: [String],
+        logoImage: Data
+    ) {
+        self.schoolName = schoolName
+        self.line = line
+        self.departments = departments
+        self.logoImage = logoImage
+    }
+}

--- a/Service/Sources/Domain/SchoolDoamin/DTO/Request/ModifySchoolRequestDTO.swift
+++ b/Service/Sources/Domain/SchoolDoamin/DTO/Request/ModifySchoolRequestDTO.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-public struct ModifySchoolRequestDTO: Encodable {
-    public let schoolName: String
-    public let line: LineType
-    public let logoImage: Data
-}

--- a/Service/Sources/Domain/SchoolDoamin/DTO/Response/SchoolListResponseDTO.swift
+++ b/Service/Sources/Domain/SchoolDoamin/DTO/Response/SchoolListResponseDTO.swift
@@ -4,7 +4,7 @@ public struct SchoolListResponseDTO: Decodable {
     public let schoolID: Int
     public let schoolName: String
     public let line: LineType
-    public let departments: [DepartmentResponseDTO]
+    public let departments: [String]
     public let logoImageURL: String
     public let clubs: [SchoolWithClubsResponseDTO]
 
@@ -24,7 +24,7 @@ extension SchoolListResponseDTO {
             schoolID: schoolID,
             schoolName: schoolName,
             line: line,
-            departments: departments.map { $0.toDomain() },
+            departments: departments,
             logoImageURL: logoImageURL,
             clubs: clubs.map { $0.toDomain() }
         )

--- a/Service/Sources/Domain/SchoolDoamin/DataSource/RemoteSchoolDataSource.swift
+++ b/Service/Sources/Domain/SchoolDoamin/DataSource/RemoteSchoolDataSource.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol RemoteSchoolDataSource: BaseRemoteDataSource<SchoolAPI> {
     func fetchSchoolList() async throws -> [SchoolListEntity]
     func fetchAllSchoolName() async throws -> [String]
-    func createdSchool(req: InputSchoolInfoRequestDTO) async throws
-    func modifySchool(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws
+    func createdSchool(logoImage: Data, req: InputSchoolInfoRequestDTO) async throws
+    func modifySchool(schoolID: Int, logoImage: Data, req: InputSchoolInfoRequestDTO) async throws
     func deleteSchool(schoolID: Int) async throws
 }

--- a/Service/Sources/Domain/SchoolDoamin/DataSource/RemoteSchoolDataSource.swift
+++ b/Service/Sources/Domain/SchoolDoamin/DataSource/RemoteSchoolDataSource.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol RemoteSchoolDataSource: BaseRemoteDataSource<SchoolAPI> {
     func fetchSchoolList() async throws -> [SchoolListEntity]
     func fetchAllSchoolName() async throws -> [String]
-    func createdSchool(req: CreatedSchoolRequestDTO) async throws
-    func modifySchool(schoolID: Int, req: ModifySchoolRequestDTO) async throws
+    func createdSchool(req: InputSchoolInfoRequestDTO) async throws
+    func modifySchool(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws
     func deleteSchool(schoolID: Int) async throws
 }

--- a/Service/Sources/Domain/SchoolDoamin/Repository/SchoolRepository.swift
+++ b/Service/Sources/Domain/SchoolDoamin/Repository/SchoolRepository.swift
@@ -1,7 +1,9 @@
+import Foundation
+
 public protocol SchoolRepository {
     func fetchSchoolList() async throws -> [SchoolListEntity]
     func fetchAllSchoolName() async throws -> [String]
-    func createdSchool(req: InputSchoolInfoRequestDTO) async throws
-    func modifySchool(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws
+    func createdSchool(logoImage: Data, req: InputSchoolInfoRequestDTO) async throws
+    func modifySchool(schoolID: Int, logoImage: Data, req: InputSchoolInfoRequestDTO) async throws
     func deleteSchool(schoolID: Int) async throws
 }

--- a/Service/Sources/Domain/SchoolDoamin/Repository/SchoolRepository.swift
+++ b/Service/Sources/Domain/SchoolDoamin/Repository/SchoolRepository.swift
@@ -1,7 +1,7 @@
 public protocol SchoolRepository {
     func fetchSchoolList() async throws -> [SchoolListEntity]
     func fetchAllSchoolName() async throws -> [String]
-    func createdSchool(req: CreatedSchoolRequestDTO) async throws
-    func modifySchool(schoolID: Int, req: ModifySchoolRequestDTO) async throws
+    func createdSchool(req: InputSchoolInfoRequestDTO) async throws
+    func modifySchool(schoolID: Int, req: InputSchoolInfoRequestDTO) async throws
     func deleteSchool(schoolID: Int) async throws
 }

--- a/Service/Sources/Domain/SchoolDoamin/UseCase/CreatedSchoolUseCase.swift
+++ b/Service/Sources/Domain/SchoolDoamin/UseCase/CreatedSchoolUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol CreatedSchoolUseCase {
-    func callAsFunction(req: CreatedSchoolRequestDTO) async throws
+    func callAsFunction(logoImage: Data, req: InputSchoolInfoRequestDTO) async throws
 }

--- a/Service/Sources/Domain/SchoolDoamin/UseCase/ModifySchoolUseCase.swift
+++ b/Service/Sources/Domain/SchoolDoamin/UseCase/ModifySchoolUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol ModifySchoolUseCase {
-    func callAsFunction(schoolID: Int, req: ModifySchoolRequestDTO) async throws
+    func callAsFunction(schoolID: Int, logoImage: Data, req: InputSchoolInfoRequestDTO) async throws
 }


### PR DESCRIPTION
## 💡 배경 및 개요
학교 정보 입력 페이지에 기능을 추가했어요

Resolves: #391 

## 📃 작업내용
- 학교 생성
- 학교 수정
- 학교 삭제
위 기능들을 추가했어요.

## 🙋‍♂️ 리뷰노트
CreatedSchoolRequestDTO, ModifySchoolReqestDTO 두 개로 나누어져있던 requestDTO를 InputSchoolInfoRequestDTO 하나로 사용하도록 변경했어요.
InputSchoolInfoRequestDTO에서 logoImage를 분리했어요.
SchoolLineBottomSheet의 RadioButton 선택범위가 좁아서 더 넓혀줬어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?