### PR TITLE
🔀 :: [#398] 강의 신청자 명단 페이지 디자인 변경사항 적용

### DIFF
--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -561,6 +561,9 @@ private class LectureApplicantListDependency5bfdb7310dde792c0738Provider: Lectur
     var setLectureCompletionUseCase: any SetLectureCompletionUseCase {
         return appComponent.setLectureCompletionUseCase
     }
+    var fetchAppliedLectureStudentDetailUseCase: any FetchAppliedLectureStudentDetailUseCase {
+        return appComponent.fetchAppliedLectureStudentDetailUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -1160,6 +1163,7 @@ extension LectureApplicantListComponent: Registration {
     public func registerItems() {
         keyPathToName[\LectureApplicantListDependency.fetchApplicantListUseCase] = "fetchApplicantListUseCase-any FetchApplicantListUseCase"
         keyPathToName[\LectureApplicantListDependency.setLectureCompletionUseCase] = "setLectureCompletionUseCase-any SetLectureCompletionUseCase"
+        keyPathToName[\LectureApplicantListDependency.fetchAppliedLectureStudentDetailUseCase] = "fetchAppliedLectureStudentDetailUseCase-any FetchAppliedLectureStudentDetailUseCase"
     }
 }
 extension UserListComponent: Registration {

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/Component/ApplicantStudentDetailBottomSheet.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/Component/ApplicantStudentDetailBottomSheet.swift
@@ -1,9 +1,124 @@
-//
-//  ApplicantStudentDetailBottomSheet.swift
-//  Bitgouel
-//
-//  Created by 정윤서 on 8/8/24.
-//  Copyright © 2024 team.msg. All rights reserved.
-//
+import SwiftUI
+import Service
 
-import Foundation
+struct ApplicantStudentDetailBottomSheet: View {
+    let studentInfo: AppliedLectureStudentDetailEntity?
+    let cancel: (Bool) -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            if let studentInfo = studentInfo {
+                HStack {
+                    BitgouelText(
+                        text: "학생 상세",
+                        font: .title3
+                    )
+
+                    Spacer()
+                    
+                    Button {
+                        cancel(false)
+                    } label: {
+                        BitgouelAsset.Icons.cancel.swiftUIImage
+                            .resizable()
+                            .renderingMode(.template)
+                            .foregroundColor(.bitgouel(.greyscale(.g7)))
+                            .frame(width: 24, height: 24)
+                    }
+                }
+                .padding(.vertical, 8)
+
+                VStack(alignment: .leading, spacing: 24) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text("이름")
+                            .bitgouelFont(.caption, color: .greyscale(.g4))
+                        
+                        BitgouelText(
+                            text: studentInfo.name,
+                            font: .text1
+                        )
+                    }
+                    
+                    infoForm(title: "학교", text: studentInfo.school)
+                    
+                    infoForm(
+                        title: "학번 | 기수",
+                        text: "\(studentInfo.grade)학년 \(studentInfo.classNumber)반 \(studentInfo.number)번 | \(studentInfo.cohort)기"
+                    )
+                    
+                    infoForm(title: "이메일", text: studentInfo.email)
+                    
+                    infoForm(title: "전화번호", text: studentInfo.phoneNumber.withHypen)
+                    
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text("강의 이수 여부")
+                            .bitgouelFont(.caption, color: .greyscale(.g4))
+                        
+                        completionStatusRow()
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 28)
+        .frame(height: 500)
+    }
+    
+    @ViewBuilder
+    func infoForm(
+        title: String,
+        text: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .bitgouelFont(.caption, color: .greyscale(.g4))
+            
+            BitgouelText(
+                text: text,
+                font: .text3
+            )
+        }
+    }
+    
+    @ViewBuilder
+    func completionStatusRow() -> some View {
+        if let completeStatus = studentInfo?.completeStatus {
+            switch completeStatus {
+            case .notCompletedYet:
+                completionStatusText(state: "이수 미완료", grade: 0)
+                
+            case .completedIn3RD:
+                completionStatusText(state: "이수완료", grade: 3)
+                
+            case .completedIn2RD:
+                completionStatusText(state: "이수완료", grade: 2)
+                
+            case .completedIn1RD:
+                completionStatusText(state: "이수완료", grade: 1)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    func completionStatusText(
+        state: String,
+        grade: Int
+    ) -> some View {
+        HStack(spacing: 4) {
+            Text(state)
+                .bitgouelFont(.text3, color: .primary(.p5))
+            
+            if let date = studentInfo?.currentCompletedDate {
+                HStack(spacing: 0) {
+                    BitgouelText(text: date.toStringCustomFormat(format: "yyyy년 M월 d일"), font: .caption)
+                    
+                    if state == "이수완료" {
+                        BitgouelText(text: "(\(grade)학년)", font: .caption)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/Component/ApplicantStudentDetailBottomSheet.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/Component/ApplicantStudentDetailBottomSheet.swift
@@ -1,0 +1,9 @@
+//
+//  ApplicantStudentDetailBottomSheet.swift
+//  Bitgouel
+//
+//  Created by 정윤서 on 8/8/24.
+//  Copyright © 2024 team.msg. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListComponent.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListComponent.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public protocol LectureApplicantListDependency: Dependency {
     var fetchApplicantListUseCase: any FetchApplicantListUseCase { get }
     var setLectureCompletionUseCase: any SetLectureCompletionUseCase { get }
+    var fetchAppliedLectureStudentDetailUseCase: any FetchAppliedLectureStudentDetailUseCase { get }
 }
 
 public final class LectureApplicantListComponent: Component<LectureApplicantListDependency>,
@@ -14,7 +15,8 @@ public final class LectureApplicantListComponent: Component<LectureApplicantList
             viewModel: LectureApplicantListViewModel(
                 lectureID: lectureID,
                 fetchApplicantListUseCase: dependency.fetchApplicantListUseCase,
-                setLectureCompletionUseCase: dependency.setLectureCompletionUseCase
+                setLectureCompletionUseCase: dependency.setLectureCompletionUseCase,
+                fetchAppliedLectureStudentDetailUseCase: dependency.fetchAppliedLectureStudentDetailUseCase
             )
         )
     }

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
@@ -9,6 +9,8 @@ struct LectureApplicantListView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            checkAllButton()
+
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 12) {
                     ForEach(viewModel.applicantList, id: \.studentID) { student in
@@ -17,7 +19,13 @@ struct LectureApplicantListView: View {
                             state: $viewModel.state,
                             isSelected: Binding(
                                 get: { student.isComplete },
-                                set: { isComplete in } 
+                                set: { isSelected in
+                                    if isSelected {
+                                        viewModel.insertStudent(studentID: student.studentID)
+                                    } else {
+                                        viewModel.removeStudent(studentID: student.studentID)
+                                    }
+                                }
                             )
                         )
 
@@ -29,6 +37,9 @@ struct LectureApplicantListView: View {
 
             Spacer()
         }
+        .overlay(alignment: .bottom) {
+            stateChangeButton()
+        }
         .padding(.horizontal, 28)
         .onAppear {
             viewModel.onAppear()
@@ -36,10 +47,83 @@ struct LectureApplicantListView: View {
         .refreshable {
             viewModel.onAppear()
         }
-        .navigationTitle("강의 신청자 명단")
+        .navigationTitle("강의 \(viewModel.state.rawValue)")
         .bitgouelToast(
             text: viewModel.errorMessage,
             isShowing: $viewModel.isErrorOccurred
         )
+        .bitgouelAlert(
+            title: "선택한 학생의 강의 이수를 \n확정하시겠습니까?",
+            description: "한 번 이수를 확정하면 수정할 수 없습니다!",
+            isShowing: $viewModel.isShowingConfirmCompletionAlert,
+            alertActions: [
+                .init(
+                    text: "취소",
+                    style: .cancel,
+                    action: {
+                        viewModel.updateIsShowingConfirmCompletionAlert(isShowing: false)
+                    }
+                ),
+                .init(
+                    text: "확정",
+                    style: .default,
+                    action: {
+                        viewModel.setLectureCompletion {
+                            viewModel.updateIsShowingConfirmCompletionAlert(isShowing: false)
+                            viewModel.updateState(state: .general)
+                        }
+                    }
+                )
+            ]
+        )
+    }
+
+    @ViewBuilder
+    func stateChangeButton() -> some View {
+        switch viewModel.state {
+        case .general:
+            BitgouelButton(
+                text: "이수 여부 체크",
+                style: .primary
+            ) {
+                viewModel.updateState(state: .check)
+            }
+
+        case .check:
+            BitgouelButton(
+                text: "선택 학생 이수 확정",
+                style: .primary
+            ) {
+                viewModel.updateIsShowingConfirmCompletionAlert(isShowing: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    func checkAllButton() -> some View {
+        switch viewModel.state {
+        case .general:
+            EmptyView()
+
+        case .check:
+            VStack(alignment: .leading, spacing: 4) {
+                Text("전체")
+                    .bitgouelFont(.caption, color: .greyscale(.g4))
+                
+                CheckButton(
+                    isSelected: Binding(
+                        get: { viewModel.isSelectedCheckAllButton },
+                        set: { isSelected in
+                            if isSelected {
+                                viewModel.insertAllStudent()
+                            } else {
+                                viewModel.removeAllStudent()
+                            }
+                            viewModel.updateIsSelectedCheckAllButton(isSelected: isSelected)
+                        }
+                    )
+                )
+            }
+        }
     }
 }

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
@@ -28,6 +28,9 @@ struct LectureApplicantListView: View {
                                 }
                             )
                         )
+                        .onTapGesture {
+                            viewModel.updateIsShowingApplicantStudentDetailBottomSheet(isShowing: true)
+                        }
 
                         Divider()
                     }
@@ -76,6 +79,12 @@ struct LectureApplicantListView: View {
                 )
             ]
         )
+        .bitgouelBottomSheet(isShowing: $viewModel.isShowingApplicantStudentDetailBottomSheet) {
+            ApplicantStudentDetailBottomSheet(
+                studentInfo: viewModel.studentDetailInfo) { cancel in
+                    viewModel.updateIsShowingApplicantStudentDetailBottomSheet(isShowing: cancel)
+                }
+        }
     }
 
     @ViewBuilder

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
@@ -29,6 +29,7 @@ struct LectureApplicantListView: View {
                             )
                         )
                         .onTapGesture {
+                            viewModel.fetchSelectedStudentDetail(studentID: student.studentID)
                             viewModel.updateIsShowingApplicantStudentDetailBottomSheet(isShowing: true)
                         }
 

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
@@ -1,18 +1,19 @@
 import Foundation
 import Service
 
-enum LectureApplicantListPageState {
-    case general
-    case check
+enum LectureApplicantListPageState: String {
+    case general = "신청자 명단"
+    case check = "이수 선택"
 }
 
 final class LectureApplicantListViewModel: BaseViewModel {
     @Published var applicantList: [ApplicantInfoEntity] = []
     @Published var selectedStudentID: String = ""
-    @Published var isComplete: Bool = false
+    @Published var isShowingConfirmCompletionAlert = false
     @Published var state: LectureApplicantListPageState = .general
+    @Published var isSelectedCheckAllButton: Bool = false
+    @Published var students: Set<String> = []
     var lectureID: String = ""
-    var students: [String] = []
 
     private let fetchApplicantListUseCase: any FetchApplicantListUseCase
     private let setLectureCompletionUseCase: any SetLectureCompletionUseCase
@@ -27,13 +28,52 @@ final class LectureApplicantListViewModel: BaseViewModel {
         self.setLectureCompletionUseCase = setLectureCompletionUseCase
     }
 
-    func updateApplicantInfo(isSelected: Bool, studentID: String) {
-        isComplete = isSelected
-        selectedStudentID = studentID
+    func updateIsSelectedCheckAllButton(isSelected: Bool) {
+        isSelectedCheckAllButton = isSelected
+    }
+
+    func updateIsShowingConfirmCompletionAlert(isShowing: Bool) {
+        isShowingConfirmCompletionAlert = isShowing
     }
 
     func updateState(state: LectureApplicantListPageState) {
         self.state = state
+    }
+
+    func removeStudent(studentID: String) {
+        guard students.contains(studentID) else { return }
+        guard let applicantListIndex = applicantList.map(\.studentID).firstIndex(of: studentID) else { return }
+
+        students.remove(studentID)
+        applicantList[applicantListIndex].isComplete = false
+    }
+
+    func insertStudent(studentID: String) {
+        guard let applicantListIndex = applicantList.map(\.studentID).firstIndex(of: studentID) else { return }
+        students.insert(studentID)
+        applicantList[applicantListIndex].isComplete = true
+    }
+
+    func insertAllStudent() {
+        let incompleteStudentIDs = applicantList.indices.filter {
+            !applicantList[$0].isComplete
+        }.map {
+            applicantList[$0].studentID
+        }
+
+        incompleteStudentIDs.forEach { students.insert($0) }
+
+        applicantList.indices
+            .filter { incompleteStudentIDs.contains(applicantList[$0].studentID) }
+            .forEach { applicantList[$0].isComplete = true }
+    }
+
+    func removeAllStudent() {
+        applicantList.indices
+            .filter { students.contains(applicantList[$0].studentID) }
+            .forEach { applicantList[$0].isComplete = false }
+
+        students.removeAll()
     }
 
     @MainActor
@@ -48,13 +88,16 @@ final class LectureApplicantListViewModel: BaseViewModel {
         }
     }
 
-    func modifyApplicantWhether() {
+    @MainActor
+    func setLectureCompletion(_ success: @escaping () -> Void) {
         Task {
             do {
                 try await setLectureCompletionUseCase(
                     lectureID: lectureID,
-                    students: students
+                    students: students.joined(separator: ",")
                 )
+
+                success()
             } catch {
                 errorMessage = error.lectureDomainErrorMessage()
                 isErrorOccurred = true

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
@@ -19,15 +19,18 @@ final class LectureApplicantListViewModel: BaseViewModel {
 
     private let fetchApplicantListUseCase: any FetchApplicantListUseCase
     private let setLectureCompletionUseCase: any SetLectureCompletionUseCase
+    private let fetchAppliedLectureStudentDetailUseCase: any FetchAppliedLectureStudentDetailUseCase
 
     init(
         lectureID: String,
         fetchApplicantListUseCase: any FetchApplicantListUseCase,
-        setLectureCompletionUseCase: any SetLectureCompletionUseCase
+        setLectureCompletionUseCase: any SetLectureCompletionUseCase,
+        fetchAppliedLectureStudentDetailUseCase: any FetchAppliedLectureStudentDetailUseCase
     ) {
         self.lectureID = lectureID
         self.fetchApplicantListUseCase = fetchApplicantListUseCase
         self.setLectureCompletionUseCase = setLectureCompletionUseCase
+        self.fetchAppliedLectureStudentDetailUseCase = fetchAppliedLectureStudentDetailUseCase
     }
 
     func updateIsSelectedCheckAllButton(isSelected: Bool) {
@@ -104,6 +107,21 @@ final class LectureApplicantListViewModel: BaseViewModel {
                 )
 
                 success()
+            } catch {
+                errorMessage = error.lectureDomainErrorMessage()
+                isErrorOccurred = true
+            }
+        }
+    }
+
+    @MainActor
+    func fetchSelectedStudentDetail(studentID: String) {
+        Task {
+            do {
+                studentDetailInfo = try await fetchAppliedLectureStudentDetailUseCase(
+                    lectureID: lectureID,
+                    studentID: studentID
+                )
             } catch {
                 errorMessage = error.lectureDomainErrorMessage()
                 isErrorOccurred = true

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
@@ -13,6 +13,8 @@ final class LectureApplicantListViewModel: BaseViewModel {
     @Published var state: LectureApplicantListPageState = .general
     @Published var isSelectedCheckAllButton: Bool = false
     @Published var students: Set<String> = []
+    @Published var studentDetailInfo: AppliedLectureStudentDetailEntity?
+    @Published var isShowingApplicantStudentDetailBottomSheet: Bool = false
     var lectureID: String = ""
 
     private let fetchApplicantListUseCase: any FetchApplicantListUseCase
@@ -34,6 +36,10 @@ final class LectureApplicantListViewModel: BaseViewModel {
 
     func updateIsShowingConfirmCompletionAlert(isShowing: Bool) {
         isShowingConfirmCompletionAlert = isShowing
+    }
+
+    func updateIsShowingApplicantStudentDetailBottomSheet(isShowing: Bool) {
+        isShowingApplicantStudentDetailBottomSheet = isShowing
     }
 
     func updateState(state: LectureApplicantListPageState) {

--- a/Service/Sources/Data/DataSource/Lecture/RemoteLectureDataSourceImpl.swift
+++ b/Service/Sources/Data/DataSource/Lecture/RemoteLectureDataSourceImpl.swift
@@ -47,7 +47,7 @@ public final class RemoteLectureDataSourceImpl: BaseRemoteDataSource<LectureAPI>
         try await request(.fetchApplicantList(lectureID: lectureID), dto: FetchApplicantListResponseDTO.self).toDomain()
     }
 
-    public func setLectureCompletion(lectureID: String, students: [String]) async throws {
+    public func setLectureCompletion(lectureID: String, students: String) async throws {
         try await request(.setLectureCompletion(lectureID: lectureID, students: students))
     }
 
@@ -59,7 +59,10 @@ public final class RemoteLectureDataSourceImpl: BaseRemoteDataSource<LectureAPI>
         try await request(.modifyLecture(lectureID: lectureID, req: req))
     }
 
-    public func fetchAppliedLectureStudentDetail(lectureID: String, studentID: String) async throws -> AppliedLectureStudentDetailEntity {
+    public func fetchAppliedLectureStudentDetail(
+        lectureID: String,
+        studentID: String
+    ) async throws -> AppliedLectureStudentDetailEntity {
         try await request(.fetchAppliedLectureStudentDetail(lectureID: lectureID, studentID: studentID), dto: AppliedLectureStudentDetailResponseDTO.self).toDomain()
     }
 }

--- a/Service/Sources/Data/Repository/Lecture/LectureRepositoryImpl.swift
+++ b/Service/Sources/Data/Repository/Lecture/LectureRepositoryImpl.swift
@@ -51,7 +51,7 @@ public struct LectureRepositoryImpl: LectureRepository {
         try await remoteLectureDataSource.fetchApplicantList(lectureID: lectureID)
     }
 
-    public func setLectureCompletion(lectureID: String, students: [String]) async throws {
+    public func setLectureCompletion(lectureID: String, students: String) async throws {
         try await remoteLectureDataSource.setLectureCompletion(lectureID: lectureID, students: students)
     }
 
@@ -63,7 +63,10 @@ public struct LectureRepositoryImpl: LectureRepository {
         try await remoteLectureDataSource.modifyLecture(lectureID: lectureID, req: req)
     }
 
-    public func fetchAppliedLectureStudentDetail(lectureID: String, studentID: String) async throws -> AppliedLectureStudentDetailEntity {
+    public func fetchAppliedLectureStudentDetail(
+        lectureID: String,
+        studentID: String
+    ) async throws -> AppliedLectureStudentDetailEntity {
         try await remoteLectureDataSource.fetchAppliedLectureStudentDetail(lectureID: lectureID, studentID: studentID)
     }
 }

--- a/Service/Sources/Data/UseCase/Lecture/SetLectureCompletionUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/Lecture/SetLectureCompletionUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct SetLectureCompletionUseCaseImpl: SetLectureCompletionUseCase {
         self.lectureRepository = lectureRepository
     }
 
-    public func callAsFunction(lectureID: String, students: [String]) async throws {
+    public func callAsFunction(lectureID: String, students: String) async throws {
         try await lectureRepository.setLectureCompletion(lectureID: lectureID, students: students)
     }
 }

--- a/Service/Sources/Domain/LectureDomain/API/LectureAPI.swift
+++ b/Service/Sources/Domain/LectureDomain/API/LectureAPI.swift
@@ -13,7 +13,7 @@ public enum LectureAPI {
     case searchDivision(keyword: String)
     case fetchAppliedLectureList(studentID: String)
     case fetchApplicantList(lectureID: String)
-    case setLectureCompletion(lectureID: String, students: [String])
+    case setLectureCompletion(lectureID: String, students: String)
     case deleteLecture(lectureID: String)
     case modifyLecture(lectureID: String, req: InputLectureRequestDTO)
     case fetchAppliedLectureStudentDetail(lectureID: String, studentID: String)

--- a/Service/Sources/Domain/LectureDomain/DTO/Response/AppliedLectureStudentDetailResponseDTO.swift
+++ b/Service/Sources/Domain/LectureDomain/DTO/Response/AppliedLectureStudentDetailResponseDTO.swift
@@ -10,7 +10,7 @@ struct AppliedLectureStudentDetailResponseDTO: Decodable {
     public let school: String
     public let clubName: String
     public let cohort: Int
-    public let currentCompletedDate: Date
+    public let currentCompletedDate: Date?
     public let completeStatus: CompleteStatusType
 }
 

--- a/Service/Sources/Domain/LectureDomain/DataSource/RemoteLectureDataSource.swift
+++ b/Service/Sources/Domain/LectureDomain/DataSource/RemoteLectureDataSource.swift
@@ -12,8 +12,11 @@ public protocol RemoteLectureDataSource: BaseRemoteDataSource<LectureAPI> {
     func searchDivision(keyword: String) async throws -> [String]
     func fetchAppliedLectureList(studentID: String) async throws -> [AppliedLectureEntity]
     func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity]
-    func setLectureCompletion(lectureID: String, students: [String]) async throws
+    func setLectureCompletion(lectureID: String, students: String) async throws
     func deleteLecture(lectureID: String) async throws
     func modifyLecture(lectureID: String, req: InputLectureRequestDTO) async throws
-    func fetchAppliedLectureStudentDetail(lectureID: String, studentID: String) async throws -> AppliedLectureStudentDetailEntity
+    func fetchAppliedLectureStudentDetail(
+        lectureID: String,
+        studentID: String
+    ) async throws -> AppliedLectureStudentDetailEntity
 }

--- a/Service/Sources/Domain/LectureDomain/Entity/ApplicantInfoEntity.swift
+++ b/Service/Sources/Domain/LectureDomain/Entity/ApplicantInfoEntity.swift
@@ -8,7 +8,7 @@ public struct ApplicantInfoEntity: Equatable {
     public let number: Int
     public let school: String
     public let clubName: String
-    public let isComplete: Bool
+    public var isComplete: Bool
 
     public init(
         studentID: String,

--- a/Service/Sources/Domain/LectureDomain/Entity/AppliedLectureStudentDetailEntity.swift
+++ b/Service/Sources/Domain/LectureDomain/Entity/AppliedLectureStudentDetailEntity.swift
@@ -10,7 +10,7 @@ public struct AppliedLectureStudentDetailEntity: Equatable {
     public let school: String
     public let clubName: String
     public let cohort: Int
-    public let currentCompletedDate: Date
+    public let currentCompletedDate: Date?
     public let completeStatus: CompleteStatusType
 
     public init(
@@ -23,7 +23,7 @@ public struct AppliedLectureStudentDetailEntity: Equatable {
         school: String,
         clubName: String,
         cohort: Int,
-        currentCompletedDate: Date,
+        currentCompletedDate: Date?,
         completeStatus: CompleteStatusType
     ) {
         self.email = email

--- a/Service/Sources/Domain/LectureDomain/Repository/LectureRepository.swift
+++ b/Service/Sources/Domain/LectureDomain/Repository/LectureRepository.swift
@@ -12,8 +12,11 @@ public protocol LectureRepository {
     func searchDivision(keyword: String) async throws -> [String]
     func fetchAppliedLectureList(studentID: String) async throws -> [AppliedLectureEntity]
     func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity]
-    func setLectureCompletion(lectureID: String, students: [String]) async throws
+    func setLectureCompletion(lectureID: String, students: String) async throws
     func deleteLecture(lectureID: String) async throws
     func modifyLecture(lectureID: String, req: InputLectureRequestDTO) async throws
-    func fetchAppliedLectureStudentDetail(lectureID: String, studentID: String) async throws -> AppliedLectureStudentDetailEntity
+    func fetchAppliedLectureStudentDetail(
+        lectureID: String,
+        studentID: String
+    ) async throws -> AppliedLectureStudentDetailEntity
 }

--- a/Service/Sources/Domain/LectureDomain/UseCase/SetLectureCompletionUseCase.swift
+++ b/Service/Sources/Domain/LectureDomain/UseCase/SetLectureCompletionUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol SetLectureCompletionUseCase {
-    func callAsFunction(lectureID: String, students: [String]) async throws
+    func callAsFunction(lectureID: String, students: String) async throws
 }


### PR DESCRIPTION
## 💡 배경 및 개요
강의 신청자 명단 페이지 디자인이 변경되었어요.

Resolves: #398 

## 📃 작업내용

https://github.com/user-attachments/assets/ab9539c2-3314-48dd-aa88-52270949c51c

- 변경된 강의 신청자 명단 페이지의 디자인을 적용했어요.
- 강의 이수중인 학생 상세조회 기능을 추가해서 BottomSheet로 강의 이수중인 학생의 상세 정보를 보여주도록 했어요.

## 🙋‍♂️ 리뷰노트
- currentCompletedDate가 옵셔널 처리가 되어있지 않아서 추가했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?