### PR TITLE
🔀 :: [#395] 강의 장소 우편번호 검색 기능 추가

### DIFF
--- a/App/Sources/Feature/InputLectureFeature/Sources/InputLectureViewModel.swift
+++ b/App/Sources/Feature/InputLectureFeature/Sources/InputLectureViewModel.swift
@@ -17,7 +17,10 @@ final class InputLectureViewModel: BaseViewModel {
         lectureDates: [],
         lectureType: "상호학점인정교육과정",
         credit: 0,
-        maxRegisteredUser: 0
+        maxRegisteredUser: 0,
+        address: "",
+        locationDetails: "",
+        essentialComplete: true
     )
 
     let lectureID: String
@@ -66,7 +69,10 @@ final class InputLectureViewModel: BaseViewModel {
             lectureDates: detailInfo.lectureDates,
             lectureType: detailInfo.lectureType,
             credit: detailInfo.credit,
-            maxRegisteredUser: detailInfo.maxRegisteredUser
+            maxRegisteredUser: detailInfo.maxRegisteredUser,
+            address: detailInfo.address,
+            locationDetails: detailInfo.locationDetails,
+            essentialComplete: detailInfo.essentialComplete
         )
     }
 
@@ -106,7 +112,10 @@ final class InputLectureViewModel: BaseViewModel {
             },
             lectureType: response.lectureType,
             credit: response.credit,
-            maxRegisteredUser: response.credit
+            maxRegisteredUser: response.credit,
+            address: response.address,
+            locationDetails: response.locationDetails,
+            essentialComplete: response.essentialComplete
         )
     }
 
@@ -154,7 +163,10 @@ final class InputLectureViewModel: BaseViewModel {
                 },
                 lectureType: lectureInfo.lectureType,
                 credit: lectureInfo.credit,
-                maxRegisteredUser: lectureInfo.maxRegisteredUser
+                maxRegisteredUser: lectureInfo.maxRegisteredUser,
+                address: lectureInfo.address,
+                locationDetails: lectureInfo.locationDetails,
+                essentialComplete: lectureInfo.essentialComplete
             )
         )
     }
@@ -181,7 +193,10 @@ final class InputLectureViewModel: BaseViewModel {
                 },
                 lectureType: lectureInfo.lectureType,
                 credit: lectureInfo.credit,
-                maxRegisteredUser: lectureInfo.maxRegisteredUser
+                maxRegisteredUser: lectureInfo.maxRegisteredUser,
+                address: lectureInfo.address,
+                locationDetails: lectureInfo.locationDetails,
+                essentialComplete: lectureInfo.essentialComplete
             )
         )
     }

--- a/App/Sources/Feature/InputLectureFeature/Sources/Model/LectureDataModel.swift
+++ b/App/Sources/Feature/InputLectureFeature/Sources/Model/LectureDataModel.swift
@@ -14,4 +14,7 @@ public struct LectureDataModel: Equatable {
     let lectureType: String
     let credit: Int
     let maxRegisteredUser: Int
+    let address: String
+    let locationDetails: String
+    let essentialComplete: Bool
 }

--- a/App/Sources/Feature/LectureDetailSettingFeature/Sources/Component/View/ApplicationPeriodView.swift
+++ b/App/Sources/Feature/LectureDetailSettingFeature/Sources/Component/View/ApplicationPeriodView.swift
@@ -24,7 +24,7 @@ struct ApplicationPeriodView: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 BitgouelText(
-                    text: "마감일",
+                    text: "신청 마감일",
                     font: .text1
                 )
 

--- a/App/Sources/Feature/LectureDetailSettingFeature/Sources/Component/View/LectureLocationView.swift
+++ b/App/Sources/Feature/LectureDetailSettingFeature/Sources/Component/View/LectureLocationView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct LectureLocationView: View {
+    @Binding var isShowingPostCodeSheet: Bool
+    @Binding var address: String
+    @Binding var locationDetail: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            BitgouelText(
+                text: "강의 장소",
+                font: .text1
+            )
+
+            PickerTextField(
+                "지번, 도로명 주소 검색",
+                text: address
+            ) {
+                isShowingPostCodeSheet = true
+            }
+
+            BitgouelTextField(
+                "상세 주소 입력",
+                text: $locationDetail
+            )
+        }
+    }
+}

--- a/App/Sources/Feature/LectureDetailSettingFeature/Sources/LectureDetailSettingView.swift
+++ b/App/Sources/Feature/LectureDetailSettingFeature/Sources/LectureDetailSettingView.swift
@@ -82,6 +82,12 @@ struct LectureDetailSettingView: View {
                         )
                     )
 
+                    LectureLocationView(
+                        isShowingPostCodeSheet: $viewModel.isShowingPostCodeSheet,
+                        address: $viewModel.selectedAddress,
+                        locationDetail: $viewModel.enteredLocationDetail
+                    )
+
                     LectureDatesView(
                         lectureDatesList: viewModel.lectureDatesList
                     ) { completeDate, index in
@@ -215,6 +221,15 @@ struct LectureDetailSettingView: View {
             ) { name, id in
                 viewModel.updateInstructorInfo(name: name, id: id)
                 viewModel.resetKeyword()
+            }
+        }
+        .sheet(isPresented: $viewModel.isShowingPostCodeSheet) {
+            if let url = viewModel.postCodeWebURL {
+                KakaoPostCodeView(
+                    request: URLRequest(url: url),
+                    isShowingKakaoWebSheet: $viewModel.isShowingPostCodeSheet,
+                    address: $viewModel.selectedAddress
+                )
             }
         }
         .onTapGesture {

--- a/App/Sources/Feature/LectureDetailSettingFeature/Sources/LectureDetailSettingViewModel.swift
+++ b/App/Sources/Feature/LectureDetailSettingFeature/Sources/LectureDetailSettingViewModel.swift
@@ -46,10 +46,16 @@ final class LectureDetailSettingViewModel: BaseViewModel {
     @Published var selectedMaxRegisteredUser: Int = 0
     @Published var isShowingMaxRegisteredUserBottomSheet: Bool = false
 
+    // MARK: Location
+    @Published var isShowingPostCodeSheet: Bool = false
+    @Published var selectedAddress: String = ""
+    @Published var enteredLocationDetail: String = ""
+
     @Published var isEssential: Bool = true
     @Published var keyword: String = ""
     @Published var detailInfo: LectureDataModel
     let completion: (LectureDataModel) -> Void
+    let postCodeWebURL: URL? = URL(string: "https://uuuunseo.github.io/DaumWeb/")
 
     private let searchInstructorUseCase: any SearchInstructorUseCase
     private let searchLineUseCase: any SearchLineUseCase
@@ -240,7 +246,10 @@ final class LectureDetailSettingViewModel: BaseViewModel {
             lectureDates: lectureDatesList,
             lectureType: lectureTypeString,
             credit: selectedCredit,
-            maxRegisteredUser: selectedMaxRegisteredUser
+            maxRegisteredUser: selectedMaxRegisteredUser,
+            address: selectedAddress,
+            locationDetails: enteredLocationDetail,
+            essentialComplete: isEssential
         )
 
         completion(detailInfo)
@@ -258,6 +267,7 @@ final class LectureDetailSettingViewModel: BaseViewModel {
         updateLectureType(lectureType: detailInfo.lectureType)
         updateCredit(credit: detailInfo.credit)
         updateMaxRegisterUser(maxRegisterUser: detailInfo.maxRegisteredUser)
+        updateIsEssential(isEssential: detailInfo.essentialComplete)
     }
 
     @MainActor

--- a/App/Sources/Utils/View/KakaoPostCodeView.swift
+++ b/App/Sources/Utils/View/KakaoPostCodeView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import WebKit
+
+struct KakaoPostCodeView: UIViewRepresentable {
+    let request: URLRequest
+    var webView: WKWebView?
+    @Binding var isShowingKakaoWebSheet: Bool
+    @Binding var address: String
+    
+    init(
+        request: URLRequest,
+        isShowingKakaoWebSheet: Binding<Bool>,
+        address: Binding<String>
+    ) {
+        self.webView = WKWebView()
+        self.request = request
+        self._isShowingKakaoWebSheet = isShowingKakaoWebSheet
+        self._address = address
+        self.webView?.configuration.userContentController.add(KakaoWebController(isShowingkakaoWebSheet: _isShowingKakaoWebSheet, address: _address), name: "callBackHandler")
+    }
+    
+    func makeUIView(context: Context) -> WKWebView {
+        return webView!
+    }
+    
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        uiView.load(request)
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+    
+    class Coordinator: NSObject, WKNavigationDelegate {
+        let parent: KakaoPostCodeView
+        
+        init(parent: KakaoPostCodeView) {
+            self.parent = parent
+        }
+    }
+}
+
+class KakaoWebController: NSObject, WKScriptMessageHandler {
+    @Binding var isShowingKakaoWebSheet: Bool
+    @Binding var address: String
+    
+    init(
+        isShowingkakaoWebSheet: Binding<Bool>,
+        address: Binding<String>
+    ) {
+        self._isShowingKakaoWebSheet = isShowingkakaoWebSheet
+        self._address = address
+    }
+    
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name == "callBackHandler", let data = message.body as? [String: Any] {
+            if message.name == "callBackHandler" {
+                print("message name : \(message.name)")
+                print("post Message : \(message.body)")
+                
+                if let roadAddress = (data["roadAddress"]) as? String {
+                    print("roadAddress: \(roadAddress)")
+                    address = roadAddress
+                    print(address)
+                }
+                isShowingKakaoWebSheet.toggle()
+            }
+        }
+    }
+}
+
+
+extension KakaoPostCodeView {
+    func callJS(_ args: Any = "") {
+        webView?.evaluateJavaScript("postMessageToiOS('\(args)')") { result, error in
+            if let error {
+                print("Error \(error.localizedDescription)")
+                return
+            }
+            
+            if result == nil {
+                print("It's void function")
+                return
+            }
+            
+            print("Received Data \(result ?? "")")
+        }
+    }
+}
+

--- a/Service/Sources/Domain/LectureDomain/DTO/Request/InputLectureRequestDTO.swift
+++ b/Service/Sources/Domain/LectureDomain/DTO/Request/InputLectureRequestDTO.swift
@@ -14,6 +14,9 @@ public struct InputLectureRequestDTO: Encodable {
     public let lectureType: String
     public let credit: Int
     public let maxRegisteredUser: Int
+    public let address: String
+    public let locationDetails: String
+    public let essentialComplete: Bool
 
     public init(
         name: String,
@@ -28,7 +31,10 @@ public struct InputLectureRequestDTO: Encodable {
         lectureDates: [LectureDateInfo],
         lectureType: String,
         credit: Int,
-        maxRegisteredUser: Int
+        maxRegisteredUser: Int,
+        address: String,
+        locationDetails: String,
+        essentialComplete: Bool
     ) {
         self.name = name
         self.content = content
@@ -43,6 +49,9 @@ public struct InputLectureRequestDTO: Encodable {
         self.lectureType = lectureType
         self.credit = credit
         self.maxRegisteredUser = maxRegisteredUser
+        self.address = address
+        self.locationDetails = locationDetails
+        self.essentialComplete = essentialComplete
     }
 
     enum CodingKeys: String, CodingKey {
@@ -59,6 +68,9 @@ public struct InputLectureRequestDTO: Encodable {
         case lectureType
         case credit
         case maxRegisteredUser
+        case address
+        case locationDetails
+        case essentialComplete
     }
 
     public struct LectureDateInfo: Encodable {


### PR DESCRIPTION
## 💡 배경 및 개요
강의 개설 시 상세 정보 설정 페이지에서 강의 장소를 우편번호로 검색하는 기능이 추가되었어요.

Resolves: #395 

## 📃 작업내용

https://github.com/user-attachments/assets/efa129e3-c00b-461f-afd0-8163059d3f27

- 강의 장소 Section이 추가되었어요.
- 우편번호 검색 View를 추가했어요.
- InputLectureRequestDTO에 address, locationDetails, essentialComplete를 추가했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?