### PR TITLE
🔀 :: [#414] CI 스크립트 개선

### DIFF
--- a/.github/workflows/bitgouel-ios-ci.yml
+++ b/.github/workflows/bitgouel-ios-ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Compute dependency cache key
         id: compute_hash
-        run: echo "hash=${{ hashFiles('Tuist/Dependencies.swift') }}" >> $GITHUB_OUTPUT
+        run: echo "hash=${{ hashFiles('Tuist/Package.swift') }}" >> $GITHUB_OUTPUT
 
       - name: Check dependency cache
         uses: actions/cache@v3
@@ -67,7 +67,7 @@ jobs:
       run: tuist install
 
     - name: Test with tuist
-      run: TUIST_ENV=CI tuist test --no-selective-testing
+      run: TUIST_ENV=CI tuist build
 
     - name: Bitgouel iOS CI Discord Notification
       uses: sarisia/actions-status-discord@v1

--- a/.github/workflows/bitgouel-ios-ci.yml
+++ b/.github/workflows/bitgouel-ios-ci.yml
@@ -8,7 +8,7 @@ on:
 
 
 env:
-  CACHED_DEPENDENCY_PATHS: ${{ github.workspace }}/Tuist/Dependencies
+  CACHED_DEPENDENCY_PATHS: ${{ github.workspace }}/Tuist/.build
 
 jobs:
   prepare-dependency:
@@ -67,7 +67,7 @@ jobs:
       run: tuist install
 
     - name: Test with tuist
-      run: TUIST_ENV=CI tuist build
+      run: TUIST_ENV=CI tuist test
 
     - name: Bitgouel iOS CI Discord Notification
       uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
## 💡 배경 및 개요
Check dependency cache 부분에서 hashFiles 경로가 잘못되어 cache가 적용되지 않고 CI 스크립트가 작동하는 문제가 있었어요.
Resolves: #414 

## 📃 작업내용
- Check dependency cache부분의 hashFiles 경로를 수정했어요.
- tuist 4부터 의존성들이 .build/ 로 이동되어 경로를 수정했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?